### PR TITLE
Improve README with feature overview and usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uri
 
-A library for parsing, manipulating, and expanding URIs for [Pony](https://www.ponylang.io/).
+A library for parsing, manipulating, and expanding URIs for [Pony](https://www.ponylang.io/). Provides URI parsing per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and URI template expansion per [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570).
 
 ## Status
 
@@ -11,8 +11,14 @@ Early development. Not yet ready for use.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/uri.git --version 0.1.0`
 * `corral fetch` to fetch your dependencies
-* `use "uri"` to include this package
+* Include any of the available packages...
+  * `use "uri"` for URI parsing
+  * `use "uri/template"` for URI template expansion
 * `corral run -- ponyc` to compile your application
+
+## Usage
+
+See [examples](examples/) for URI parsing and template expansion demonstrations.
 
 ## API Documentation
 


### PR DESCRIPTION
The README had no feature overview, didn't mention the `uri/template` package, and provided no usage guidance. Someone evaluating the library from GitHub got installation instructions but no sense of what it provides or how to use it.

Changes:
- Expanded description with RFC 3986 and RFC 6570 references
- Listed both `uri` and `uri/template` packages in Installation (following semver's multi-package pattern)
- Added a Usage section pointing to the examples directory