### PR TITLE
Add missing documentation for URIPart, URI.create, and URIAuthority.create

### DIFF
--- a/uri/percent_encoding.pony
+++ b/uri/percent_encoding.pony
@@ -13,6 +13,9 @@ primitive URIPartQuery
 primitive URIPartFragment
   """Encoding rules for the fragment component."""
 
+// Selects which URI component's encoding rules PercentEncode applies.
+// Each variant corresponds to a component whose allowed-character set
+// differs per RFC 3986.
 type URIPart is
   ( URIPartUserinfo | URIPartHost | URIPartPath
   | URIPartQuery | URIPartFragment )

--- a/uri/uri.pony
+++ b/uri/uri.pony
@@ -76,6 +76,13 @@ class val URI is (Stringable & Equatable[URI])
     query': (String | None),
     fragment': (String | None))
   =>
+    """
+    Build a URI from pre-encoded components.
+
+    All string values must already be percent-encoded as appropriate for
+    their component — no encoding is applied here. Most callers will obtain
+    a `URI` from `ParseURI` rather than constructing one directly.
+    """
     scheme = scheme'
     authority = authority'
     path = path'

--- a/uri/uri_authority.pony
+++ b/uri/uri_authority.pony
@@ -18,6 +18,13 @@ class val URIAuthority is (Stringable & Equatable[URIAuthority])
     host': String,
     port': (U16 | None))
   =>
+    """
+    Build an authority from pre-encoded components.
+
+    The `userinfo` and `host` strings must already be percent-encoded —
+    no encoding is applied here. Most callers will obtain a
+    `URIAuthority` from `ParseURI` or `ParseURIAuthority`.
+    """
     userinfo = userinfo'
     host = host'
     port = port'


### PR DESCRIPTION
Add documentation for three public API elements that were missing it:

- `URIPart` type alias: comment explaining it selects per-component encoding rules for `PercentEncode`, matching the style used by `URIParseError` and `URITemplateValue`
- `URI.create`: constructor docstring noting components must be pre-encoded
- `URIAuthority.create`: constructor docstring noting components must be pre-encoded