### PR TITLE
Add URI reference resolution per RFC 3986 section 5

### DIFF
--- a/.release-notes/add-uri-reference-resolution.md
+++ b/.release-notes/add-uri-reference-resolution.md
@@ -1,0 +1,19 @@
+## Add URI reference resolution per RFC 3986 section 5
+
+Resolve relative URI references against a base URI to produce a target URI. This is the operation browsers perform when following relative links.
+
+```pony
+match (ParseURI("http://example.com/a/b/c"), ParseURI("../d"))
+| (let base: URI val, let ref': URI val) =>
+  match ResolveURI(base, ref')
+  | let target: URI val =>
+    // target.string() == "http://example.com/a/b/d"
+  end
+end
+```
+
+New API:
+
+- `ResolveURI` — resolves a reference against a base URI
+- `RemoveDotSegments` — normalizes `.` and `..` segments in a URI path
+- `BaseURINotAbsolute` / `ResolveURIError` — returned when the base URI lacks a scheme

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ make clean              # clean build artifacts + corral cache
 
 **Implemented features**:
 - URI parsing according to RFC 3986 (scheme, authority, path, query, fragment)
+- URI reference resolution according to RFC 3986 section 5
 - URI template expansion according to RFC 6570 (all 4 levels)
 
 **Planned features**:
@@ -29,7 +30,7 @@ Two packages: `uri` for RFC 3986 parsing, `uri/template` for RFC 6570 template e
 
 ### `uri` Package — RFC 3986 Parsing
 
-- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`
+- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `ResolveURI`, `ResolveURIError` (`BaseURINotAbsolute`), `RemoveDotSegments`, `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`
 - **Internal**: `_Unreachable` for unreachable code paths
 
 ### `uri/template` Package — RFC 6570 Template Expansion

--- a/examples/parsing/main.pony
+++ b/examples/parsing/main.pony
@@ -96,3 +96,41 @@ actor Main
     | let e: InvalidPercentEncoding val =>
       env.out.print("Decode error: " + e.string())
     end
+
+    env.out.print("")
+
+    // URI reference resolution (RFC 3986 section 5)
+    env.out.print("URI Reference Resolution")
+    env.out.print("========================")
+    env.out.print("")
+
+    match ParseURI("http://example.com/a/b/c")
+    | let base: URI val =>
+      env.out.print("Base: " + base.string())
+      env.out.print("")
+
+      // Relative path with dot segments
+      _resolve(env, base, "../d")
+
+      // Fragment-only reference
+      _resolve(env, base, "#section2")
+
+      // Absolute reference (ignores base entirely)
+      _resolve(env, base, "https://other.com/page")
+    | let e: URIParseError val =>
+      env.out.print("Parse error: " + e.string())
+    end
+
+  fun _resolve(env: Env, base: URI val, reference_str: String) =>
+    match ParseURI(reference_str)
+    | let reference: URI val =>
+      match ResolveURI(base, reference)
+      | let result: URI val =>
+        env.out.print("  resolve(\"" + reference_str + "\") = "
+          + result.string())
+      | let e: ResolveURIError val =>
+        env.out.print("  resolve error: " + e.string())
+      end
+    | let e: URIParseError val =>
+      env.out.print("  parse error: " + e.string())
+    end

--- a/uri/_test.pony
+++ b/uri/_test.pony
@@ -49,3 +49,24 @@ actor \nodoc\ Main is TestList
     test(_TestQueryParamsGetAll)
     test(_TestQueryParamsContains)
     test(_TestQueryParamsSize)
+
+    // RemoveDotSegments tests
+    test(Property1UnitTest[String val](_PropertyDotSegmentsIdempotent))
+    test(Property1UnitTest[String val](_PropertyDotSegmentsNoDots))
+    test(Property1UnitTest[String val](
+      _PropertyDotSegmentsPreservesAbsolute))
+    test(_TestRemoveDotSegmentsKnownGood)
+
+    // ResolveURI tests
+    test(Property1UnitTest[_ResolveInput](
+      _PropertyResolveResultAbsolute))
+    test(Property1UnitTest[_AbsoluteURIInput](
+      _PropertyResolveEmptyRef))
+    test(Property1UnitTest[(_AbsoluteURIInput, _AbsoluteURIInput)](
+      _PropertyAbsoluteRefIgnoresBase))
+    test(Property1UnitTest[_ValidURIInput](
+      _PropertyNonAbsoluteBaseRejected))
+    test(Property1UnitTest[_ResolveInput](_PropertyResolveRoundtrip))
+    test(_TestResolveURIRFCNormal)
+    test(_TestResolveURIRFCAbnormal)
+    test(_TestResolveURIEdgeCases)

--- a/uri/_test_remove_dot_segments.pony
+++ b/uri/_test_remove_dot_segments.pony
@@ -1,0 +1,232 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyDotSegmentsIdempotent is Property1[String val]
+  """
+  Applying RemoveDotSegments twice produces the same result as once.
+  """
+  fun name(): String => "uri/remove_dot_segments/idempotent"
+
+  fun gen(): Generator[String val] =>
+    _AnyPathGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let once = RemoveDotSegments(arg1)
+    let twice = RemoveDotSegments(once)
+    ph.assert_eq[String val](once, twice,
+      "not idempotent for: " + arg1)
+
+class \nodoc\ iso _PropertyDotSegmentsNoDots is Property1[String val]
+  """
+  The output of RemoveDotSegments never contains standalone "." or ".."
+  segments.
+  """
+  fun name(): String => "uri/remove_dot_segments/no_dots_in_output"
+
+  fun gen(): Generator[String val] =>
+    _DotPathGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let result = RemoveDotSegments(arg1)
+    // Check that none of the segments are "." or ".."
+    ph.assert_true(
+      not _has_dot_segment(result),
+      "dot segment in output for input: " + arg1
+        + " output: " + result)
+
+  fun _has_dot_segment(path: String val): Bool =>
+    """
+    Check if path contains a standalone "." or ".." segment.
+    A segment is delimited by "/" or string boundaries.
+    """
+    var start: USize = 0
+    var i: USize = 0
+    while i <= path.size() do
+      // Use if/else instead of Bool.op_or — Pony's `or` is not
+      // short-circuit, so `(i == path.size()) or (path(i)? == '/')`
+      // would evaluate path(i)? even at end-of-string.
+      let at_boundary = if i == path.size() then
+        true
+      else
+        try path(i)? == '/' else false end
+      end
+      if at_boundary then
+        let seg = path.substring(start.isize(), i.isize())
+        if (consume seg == ".") or
+          (path.substring(start.isize(), i.isize()) == "..")
+        then
+          return true
+        end
+        start = i + 1
+      end
+      i = i + 1
+    end
+    false
+
+class \nodoc\ iso _PropertyDotSegmentsPreservesAbsolute
+  is Property1[String val]
+  """
+  If the input starts with "/" the output also starts with "/".
+  """
+  fun name(): String => "uri/remove_dot_segments/preserves_absolute"
+
+  fun gen(): Generator[String val] =>
+    _DotPathGenerator.absolute()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let result = RemoveDotSegments(arg1)
+    ph.assert_true(
+      try result(0)? == '/' else false end,
+      "lost leading / for input: " + arg1
+        + " output: " + result)
+
+class \nodoc\ iso _TestRemoveDotSegmentsKnownGood is UnitTest
+  """
+  RFC 3986 section 5.2.4 examples and edge cases.
+  """
+  fun name(): String => "uri/remove_dot_segments/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // RFC 3986 section 5.4 resolution examples (path portion)
+    _assert(h, "/a/b/c/./../../g", "/a/g")
+    _assert(h, "mid/content=5/../6", "mid/6")
+
+    // Excess ".." clamps to root
+    _assert(h, "/a/b/../../../g", "/g")
+
+    // Trailing dot segments
+    _assert(h, "/.", "/")
+    _assert(h, "/..", "/")
+
+    // Bare dot segments
+    _assert(h, ".", "")
+    _assert(h, "..", "")
+
+    // Leading dot segments
+    _assert(h, "./a", "a")
+    _assert(h, "../a", "a")
+
+    // Empty path
+    _assert(h, "", "")
+
+    // No-dot paths unchanged
+    _assert(h, "/a/b/c", "/a/b/c")
+    _assert(h, "/", "/")
+    _assert(h, "a/b", "a/b")
+
+    // Multiple consecutive dot segments
+    _assert(h, "/a/b/c/../../d", "/a/d")
+    _assert(h, "/a/b/./c/./d", "/a/b/c/d")
+    _assert(h, "/a/b/../c/../d", "/a/d")
+
+    // Trailing slashes preserved
+    _assert(h, "/a/b/c/../", "/a/b/")
+    _assert(h, "/a/b/c/./", "/a/b/c/")
+
+    // Deep excess ".."
+    _assert(h, "/../../../g", "/g")
+    _assert(h, "/a/../../../../g", "/g")
+
+    // Mixed leading and internal — step A strips "./" or "../", then
+    // the remaining "a/../b" resolves to "/b" because removing "a"
+    // from an output with no "/" clears it, leaving the "/" from "/../"
+    _assert(h, "./a/../b", "/b")
+    _assert(h, "../a/../b", "/b")
+
+    // Dots that are NOT dot segments (contain additional characters)
+    _assert(h, "/a.html", "/a.html")
+    _assert(h, "/a..b", "/a..b")
+    _assert(h, "/a/b.c/d", "/a/b.c/d")
+    _assert(h, "/.hidden", "/.hidden")
+    _assert(h, "/a/..suffix", "/a/..suffix")
+
+  fun _assert(h: TestHelper, input: String, expected: String) =>
+    h.assert_eq[String val](expected, RemoveDotSegments(input),
+      "RemoveDotSegments(" + input + ")")
+
+// -- Generators --
+
+primitive _DotPathGenerator
+  """
+  Generates paths likely to contain dot segments. Mixes fixed RFC examples
+  with randomly composed paths built from segments including ".", "..", and
+  normal path components.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, Generators.one_of[String val]([
+        "/a/b/c/./../../g"
+        "mid/content=5/../6"
+        "/a/b/../../../g"
+        "/."
+        "/.."
+        "."
+        ".."
+        "./a"
+        "../a"
+        ""
+        "/a/b/c"
+        "/"
+        "/a/../b/./c"
+        "/../../../g"
+        "/./g"
+        "/../g"
+        "/a/b/c/../d"
+        "a/b/../c"
+      ]))
+      (2, _random_dot_path())
+    ])
+
+  fun absolute(): Generator[String val] =>
+    """
+    Generates absolute paths (starting with "/") that contain dot segments.
+    """
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, Generators.one_of[String val]([
+        "/a/b/c/./../../g"
+        "/a/b/../../../g"
+        "/."
+        "/.."
+        "/a/../b/./c"
+        "/../../../g"
+        "/./g"
+        "/../g"
+        "/a/b/c/../d"
+        "/a/b/c"
+        "/"
+      ]))
+      (2, Generators.map2[String val, String val, String val](
+        Generators.one_of[String val](
+          ["/a"; "/b"; "/c"; "/x/y"; "/foo/bar"]),
+        Generators.one_of[String val](
+          ["/./"; "/../"; "/."; "/.."; "/./a"; "/../b"
+           "/a/./b"; "/a/../b"; "/./../"]),
+        {(prefix, suffix) => prefix + suffix }))
+    ])
+
+  fun _random_dot_path(): Generator[String val] =>
+    Generators.map2[String val, String val, String val](
+      Generators.one_of[String val](
+        ["/a"; "/b"; "/c"; ""; "/x/y"; "/foo"; "a"; "a/b"]),
+      Generators.one_of[String val](
+        ["/./"; "/../"; "/."; "/.."; "/./a"; "/../b"
+         "/a/./b"; "/a/../b"; "/./../"; "/../../"
+         "./x"; "../x"]),
+      {(prefix, suffix) => prefix + suffix })
+
+primitive _AnyPathGenerator
+  """
+  Generates a mix of dot-containing paths and plain paths (no dots).
+  Used for the idempotency property test.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, _DotPathGenerator())
+      (1, Generators.one_of[String val](
+        ["/a/b/c"; "/foo"; "bar/baz"; ""; "/"; "/index.html"
+         "/a.b/c.d"; "relative"; "/path/to/resource"
+         "no-dots-here"; "/simple"]))
+    ])

--- a/uri/_test_resolve_uri.pony
+++ b/uri/_test_resolve_uri.pony
@@ -1,0 +1,407 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyResolveResultAbsolute
+  is Property1[_ResolveInput]
+  """
+  For any absolute base and any reference, the resolved URI always has a
+  scheme.
+  """
+  fun name(): String => "uri/resolve_uri/result_always_absolute"
+
+  fun gen(): Generator[_ResolveInput] =>
+    _ResolveInputGenerator()
+
+  fun ref property(arg1: _ResolveInput, ph: PropertyHelper) =>
+    let base = URI(arg1.base.scheme, arg1.base.authority,
+      arg1.base.path, arg1.base.query, arg1.base.fragment)
+    let reference = URI(arg1.reference.scheme, arg1.reference.authority,
+      arg1.reference.path, arg1.reference.query, arg1.reference.fragment)
+    match ResolveURI(base, reference)
+    | let result: URI val =>
+      ph.assert_true(
+        match result.scheme
+        | let _: String => true
+        else false
+        end,
+        "result has no scheme for base: " + base.string()
+          + " ref: " + reference.string())
+    | let e: ResolveURIError val =>
+      ph.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _PropertyResolveEmptyRef
+  is Property1[_AbsoluteURIInput]
+  """
+  Resolving an empty reference against a base returns the base URI with the
+  fragment dropped (fragment always comes from the reference, and an empty
+  reference has no fragment).
+  """
+  fun name(): String => "uri/resolve_uri/empty_ref_returns_base"
+
+  fun gen(): Generator[_AbsoluteURIInput] =>
+    _AbsoluteURIInputGenerator()
+
+  fun ref property(arg1: _AbsoluteURIInput, ph: PropertyHelper) =>
+    let base = URI(arg1.scheme, arg1.authority,
+      arg1.path, arg1.query, arg1.fragment)
+    let empty_ref = URI(None, None, "", None, None)
+    match ResolveURI(base, empty_ref)
+    | let result: URI val =>
+      let expected = URI(arg1.scheme, arg1.authority,
+        arg1.path, arg1.query, None)
+      ph.assert_true(result == expected,
+        "expected " + expected.string() + " got " + result.string())
+    | let e: ResolveURIError val =>
+      ph.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _PropertyAbsoluteRefIgnoresBase
+  is Property1[(_AbsoluteURIInput, _AbsoluteURIInput)]
+  """
+  When the reference has a scheme, the result's scheme matches the
+  reference's scheme regardless of the base.
+  """
+  fun name(): String => "uri/resolve_uri/absolute_ref_ignores_base"
+
+  fun gen(): Generator[(_AbsoluteURIInput, _AbsoluteURIInput)] =>
+    Generators.zip2[_AbsoluteURIInput, _AbsoluteURIInput](
+      _AbsoluteURIInputGenerator(),
+      _AbsoluteURIInputGenerator())
+
+  fun ref property(
+    arg1: (_AbsoluteURIInput, _AbsoluteURIInput),
+    ph: PropertyHelper)
+  =>
+    (let base_in, let ref_in) = arg1
+    let base = URI(base_in.scheme, base_in.authority,
+      base_in.path, base_in.query, base_in.fragment)
+    let reference = URI(ref_in.scheme, ref_in.authority,
+      ref_in.path, ref_in.query, ref_in.fragment)
+    match ResolveURI(base, reference)
+    | let result: URI val =>
+      match result.scheme
+      | let s: String =>
+        ph.assert_eq[String val](ref_in.scheme, s)
+      else
+        ph.fail("result has no scheme")
+      end
+    | let e: ResolveURIError val =>
+      ph.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _PropertyNonAbsoluteBaseRejected
+  is Property1[_ValidURIInput]
+  """
+  A base URI without a scheme always produces BaseURINotAbsolute, regardless
+  of the reference.
+  """
+  fun name(): String => "uri/resolve_uri/non_absolute_base_rejected"
+
+  fun gen(): Generator[_ValidURIInput] =>
+    _ValidURIInputGenerator()
+
+  fun ref property(arg1: _ValidURIInput, ph: PropertyHelper) =>
+    let base = URI(None, None, "/some/path", "query", "frag")
+    let reference = URI(arg1.scheme, arg1.authority, arg1.path,
+      arg1.query, arg1.fragment)
+    match ResolveURI(base, reference)
+    | let _: URI val =>
+      ph.fail("expected BaseURINotAbsolute")
+    | let _: BaseURINotAbsolute => ph.assert_true(true)
+    end
+
+class \nodoc\ iso _PropertyResolveRoundtrip
+  is Property1[_ResolveInput]
+  """
+  The resolved URI roundtrips through string() and ParseURI: parsing the
+  string form produces an equal URI.
+  """
+  fun name(): String => "uri/resolve_uri/roundtrip"
+
+  fun gen(): Generator[_ResolveInput] =>
+    _ResolveInputGenerator()
+
+  fun ref property(arg1: _ResolveInput, ph: PropertyHelper) =>
+    let base = URI(arg1.base.scheme, arg1.base.authority,
+      arg1.base.path, arg1.base.query, arg1.base.fragment)
+    let reference = URI(arg1.reference.scheme, arg1.reference.authority,
+      arg1.reference.path, arg1.reference.query, arg1.reference.fragment)
+    match ResolveURI(base, reference)
+    | let result: URI val =>
+      match ParseURI(result.string())
+      | let reparsed: URI val =>
+        ph.assert_true(result == reparsed,
+          "roundtrip failed for: " + result.string())
+      | let e: URIParseError val =>
+        ph.fail("reparse failed for: " + result.string()
+          + " error: " + e.string())
+      end
+    | let e: ResolveURIError val =>
+      ph.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestResolveURIRFCNormal is UnitTest
+  """
+  RFC 3986 section 5.4.1 — normal resolution examples.
+  Base: http://a/b/c/d;p?q
+  """
+  fun name(): String => "uri/resolve_uri/rfc_normal"
+
+  fun ref apply(h: TestHelper) =>
+    let base = "http://a/b/c/d;p?q"
+    _AssertResolve(h, base, "g:h",      "g:h")
+    _AssertResolve(h, base, "g",        "http://a/b/c/g")
+    _AssertResolve(h, base, "./g",      "http://a/b/c/g")
+    _AssertResolve(h, base, "g/",       "http://a/b/c/g/")
+    _AssertResolve(h, base, "/g",       "http://a/g")
+    _AssertResolve(h, base, "//g",      "http://g")
+    _AssertResolve(h, base, "?y",       "http://a/b/c/d;p?y")
+    _AssertResolve(h, base, "g?y",      "http://a/b/c/g?y")
+    _AssertResolve(h, base, "#s",       "http://a/b/c/d;p?q#s")
+    _AssertResolve(h, base, "g#s",      "http://a/b/c/g#s")
+    _AssertResolve(h, base, "g?y#s",    "http://a/b/c/g?y#s")
+    _AssertResolve(h, base, ";x",       "http://a/b/c/;x")
+    _AssertResolve(h, base, "g;x",      "http://a/b/c/g;x")
+    _AssertResolve(h, base, "g;x?y#s",  "http://a/b/c/g;x?y#s")
+    _AssertResolve(h, base, "",         "http://a/b/c/d;p?q")
+    _AssertResolve(h, base, ".",        "http://a/b/c/")
+    _AssertResolve(h, base, "./",       "http://a/b/c/")
+    _AssertResolve(h, base, "..",       "http://a/b/")
+    _AssertResolve(h, base, "../",      "http://a/b/")
+    _AssertResolve(h, base, "../g",     "http://a/b/g")
+    _AssertResolve(h, base, "../..",    "http://a/")
+    _AssertResolve(h, base, "../../",   "http://a/")
+    _AssertResolve(h, base, "../../g",  "http://a/g")
+
+class \nodoc\ iso _TestResolveURIRFCAbnormal is UnitTest
+  """
+  RFC 3986 section 5.4.2 — abnormal resolution examples.
+  Base: http://a/b/c/d;p?q
+  """
+  fun name(): String => "uri/resolve_uri/rfc_abnormal"
+
+  fun ref apply(h: TestHelper) =>
+    let base = "http://a/b/c/d;p?q"
+    // Excess ".." — clamps to root
+    _AssertResolve(h, base, "../../../g",    "http://a/g")
+    _AssertResolve(h, base, "../../../../g", "http://a/g")
+
+    // Absolute paths with dots
+    _AssertResolve(h, base, "/./g",  "http://a/g")
+    _AssertResolve(h, base, "/../g", "http://a/g")
+
+    // Compound and unnecessary dot-segment forms
+    _AssertResolve(h, base, "./../g", "http://a/b/g")
+    _AssertResolve(h, base, "./g.",   "http://a/b/c/g.")
+    _AssertResolve(h, base, "./g/.",  "http://a/b/c/g/")
+    _AssertResolve(h, base, "g/./h",  "http://a/b/c/g/h")
+    _AssertResolve(h, base, "g/../h", "http://a/b/c/h")
+
+    // Not dot segments (contain extra characters)
+    _AssertResolve(h, base, "g.",  "http://a/b/c/g.")
+    _AssertResolve(h, base, "g..", "http://a/b/c/g..")
+    _AssertResolve(h, base, ".g",  "http://a/b/c/.g")
+    _AssertResolve(h, base, "..g", "http://a/b/c/..g")
+
+    // Dot segments in mid-path
+    _AssertResolve(h, base, "g;x=1/./y",  "http://a/b/c/g;x=1/y")
+    _AssertResolve(h, base, "g;x=1/../y", "http://a/b/c/y")
+
+    // Dots in query and fragment (not path — left as-is)
+    _AssertResolve(h, base, "g?y/./x",  "http://a/b/c/g?y/./x")
+    _AssertResolve(h, base, "g?y/../x", "http://a/b/c/g?y/../x")
+    _AssertResolve(h, base, "g#s/./x",  "http://a/b/c/g#s/./x")
+    _AssertResolve(h, base, "g#s/../x", "http://a/b/c/g#s/../x")
+
+class \nodoc\ iso _TestResolveURIEdgeCases is UnitTest
+  """
+  Additional edge cases beyond the RFC 3986 section 5.4 suite.
+  """
+  fun name(): String => "uri/resolve_uri/edge_cases"
+
+  fun ref apply(h: TestHelper) =>
+    // Base with empty path + authority
+    _AssertResolve(h,
+      "http://example.com", "g", "http://example.com/g")
+
+    // Reference with authority
+    _AssertResolve(h,
+      "http://base.com/path", "//other.com/path",
+      "http://other.com/path")
+
+    // Fragment-only reference
+    _AssertResolve(h,
+      "http://example.com/path?q", "#frag",
+      "http://example.com/path?q#frag")
+
+    // Query-only reference
+    _AssertResolve(h,
+      "http://example.com/path?old", "?new",
+      "http://example.com/path?new")
+
+    // Base with userinfo and port preserved through resolution.
+    // From /a/b, "../c" goes up from directory /a/ to /, then to /c.
+    _AssertResolve(h,
+      "http://user@example.com:8080/a/b", "../c",
+      "http://user@example.com:8080/c")
+
+    // Non-absolute base rejected
+    match ParseURI("/relative/path")
+    | let base: URI val =>
+      match ParseURI("g")
+      | let ref': URI val =>
+        match ResolveURI(base, ref')
+        | let _: URI val =>
+          h.fail("expected BaseURINotAbsolute for relative base")
+        | let _: BaseURINotAbsolute => None
+        end
+      | let e: URIParseError val =>
+        h.fail("parse error: " + e.string())
+      end
+    | let e: URIParseError val =>
+      h.fail("parse error: " + e.string())
+    end
+
+primitive _AssertResolve
+  fun apply(
+    h: TestHelper,
+    base_str: String,
+    reference_str: String,
+    expected: String)
+  =>
+    match ParseURI(base_str)
+    | let base: URI val =>
+      match ParseURI(reference_str)
+      | let reference: URI val =>
+        match ResolveURI(base, reference)
+        | let result: URI val =>
+          h.assert_eq[String val](expected, result.string(),
+            "resolve(" + base_str + ", " + reference_str + ")")
+        | let e: ResolveURIError val =>
+          h.fail("resolve error for (" + base_str + ", " + reference_str
+            + "): " + e.string())
+        end
+      | let e: URIParseError val =>
+        h.fail("parse error for reference " + reference_str
+          + ": " + e.string())
+      end
+    | let e: URIParseError val =>
+      h.fail("parse error for base " + base_str + ": " + e.string())
+    end
+
+// -- Generators --
+
+class \nodoc\ val _AbsoluteURIInput
+  let scheme: String
+  let authority: (URIAuthority | None)
+  let path: String
+  let query: (String | None)
+  let fragment: (String | None)
+
+  new val create(
+    scheme': String,
+    authority': (URIAuthority | None),
+    path': String,
+    query': (String | None),
+    fragment': (String | None))
+  =>
+    scheme = scheme'
+    authority = authority'
+    path = path'
+    query = query'
+    fragment = fragment'
+
+primitive _AbsoluteURIInputGenerator
+  fun apply(): Generator[_AbsoluteURIInput] =>
+    Generators.map4[
+      (String val, URIAuthority val | None),
+      String val,
+      (String val | None),
+      (String val | None),
+      _AbsoluteURIInput](
+      _scheme_authority_gen(),
+      _path_gen(),
+      _query_gen(),
+      _fragment_gen(),
+      {(scheme_auth, path, query, fragment) =>
+        (let scheme, let authority) = scheme_auth
+        _AbsoluteURIInput(scheme, authority, path, query, fragment)
+      })
+
+  fun _scheme_authority_gen()
+    : Generator[(String val, URIAuthority val | None)]
+  =>
+    Generators.map2[
+      String val,
+      (URIAuthority val | None),
+      (String val, URIAuthority val | None)](
+      _scheme_gen(),
+      _authority_gen(),
+      {(scheme, authority) => (scheme, authority) })
+
+  fun _scheme_gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["http"; "https"; "ftp"; "ssh"])
+
+  fun _authority_gen(): Generator[(URIAuthority val | None)] =>
+    Generators.frequency[(URIAuthority val | None)]([
+      as WeightedGenerator[(URIAuthority val | None)]:
+      (1, Generators.unit[(URIAuthority val | None)](None))
+      (1, Generators.one_of[String val](
+        ["example.com"; "localhost"; "192.168.1.1"; "example.com:8080"
+         "example.com:443"])
+        .map[(URIAuthority val | None)]({(host) =>
+          match ParseURIAuthority(host)
+          | let a: URIAuthority val => a
+          else
+            URIAuthority(None, "localhost", None)
+          end
+        }))
+    ])
+
+  fun _path_gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, Generators.unit[String val](""))
+      (1, Generators.unit[String val]("/"))
+      (2, Generators.one_of[String val](
+        ["/path"; "/a/b/c"; "/index.html"; "/foo/bar/baz"
+         "/path/to/resource"]))
+    ])
+
+  fun _query_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["key=value"; "a=1&b=2"; "q=hello+world"; ""; "page=1"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _fragment_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["top"; "section1"; ""; "frag"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+class \nodoc\ val _ResolveInput
+  let base: _AbsoluteURIInput
+  let reference: _ValidURIInput
+
+  new val create(
+    base': _AbsoluteURIInput,
+    reference': _ValidURIInput)
+  =>
+    base = base'
+    reference = reference'
+
+primitive _ResolveInputGenerator
+  fun apply(): Generator[_ResolveInput] =>
+    Generators.map2[_AbsoluteURIInput, _ValidURIInput, _ResolveInput](
+      _AbsoluteURIInputGenerator(),
+      _ValidURIInputGenerator(),
+      {(base, reference) => _ResolveInput(base, reference) })

--- a/uri/remove_dot_segments.pony
+++ b/uri/remove_dot_segments.pony
@@ -1,0 +1,109 @@
+primitive RemoveDotSegments
+  """
+  Remove dot segments from a URI path per RFC 3986 section 5.2.4.
+
+  Dot segments (`.` and `..`) are special path segments used for relative
+  navigation. This algorithm resolves them into an equivalent path without
+  dot segments — e.g., `/a/b/../c` becomes `/a/c`.
+
+  Used internally by `ResolveURI` during reference resolution, but also
+  useful on its own for path normalization.
+  """
+  fun apply(path: String val): String val =>
+    """
+    Remove all `.` and `..` segments from `path`, returning the normalized
+    result. Implements the iterative algorithm from RFC 3986 section 5.2.4.
+    """
+    // Fast path: if the path can't contain dot segments, return unchanged.
+    // Check for substrings "./" and "/." which cover all mid-path and
+    // trailing dot segments, plus exact matches for bare "." and "..".
+    if (not path.contains("./")) and (not path.contains("/."))
+      and (path != ".") and (path != "..")
+    then
+      return path
+    end
+
+    let input: String ref = path.clone()
+    let output = String(path.size())
+
+    while input.size() > 0 do
+      if _starts_with(input, "../") then
+        // A: strip leading "../"
+        input.delete(0, 3)
+      elseif _starts_with(input, "./") then
+        // A: strip leading "./"
+        input.delete(0, 2)
+      elseif _starts_with(input, "/./") then
+        // B: replace leading "/./" with "/"
+        input.delete(0, 2)
+      elseif input == "/." then
+        // B: replace "/." with "/"
+        input.clear()
+        input.append("/")
+      elseif _starts_with(input, "/../") then
+        // C: replace leading "/../" with "/" and pop last output segment
+        input.delete(0, 3)
+        _remove_last_segment(output)
+      elseif input == "/.." then
+        // C: replace "/.." with "/" and pop last output segment
+        input.clear()
+        input.append("/")
+        _remove_last_segment(output)
+      elseif (input == ".") or (input == "..") then
+        // D: remove bare "." or ".."
+        input.clear()
+      else
+        // E: move first path segment from input to output
+        _move_segment(input, output)
+      end
+    end
+
+    output.clone()
+
+  fun _starts_with(s: String box, prefix: String box): Bool =>
+    (s.size() >= prefix.size())
+      and (s.compare_sub(prefix, prefix.size()) is Equal)
+
+  fun _remove_last_segment(output: String ref) =>
+    """
+    Remove the last segment and its preceding "/" (if any) from the output
+    buffer. If there is no "/" the entire buffer is cleared.
+    """
+    try
+      var i = output.size()
+      while i > 0 do
+        i = i - 1
+        if output(i)? == '/' then
+          output.truncate(i)
+          return
+        end
+      end
+    else
+      _Unreachable()
+    end
+    // No "/" found — clear everything
+    output.clear()
+
+  fun _move_segment(input: String ref, output: String ref) =>
+    """
+    Move the first path segment (including initial "/" if any) from the
+    input buffer to the output buffer.
+    """
+    var end_pos: USize = 0
+    try
+      // Include leading "/" if present
+      if (input.size() > 0) and (input(0)? == '/') then
+        end_pos = 1
+      end
+      // Advance to next "/" or end of input
+      while end_pos < input.size() do
+        if input(end_pos)? == '/' then
+          break
+        end
+        end_pos = end_pos + 1
+      end
+    else
+      _Unreachable()
+    end
+    output.append(input.substring(0, end_pos.isize()))
+    input.delete(0, end_pos)

--- a/uri/resolve_uri.pony
+++ b/uri/resolve_uri.pony
@@ -1,0 +1,108 @@
+primitive ResolveURI
+  """
+  Resolve a URI reference against a base URI per RFC 3986 section 5.
+
+  Given an absolute base URI and any URI-reference, produces the target URI
+  that the reference identifies relative to the base. This is the operation
+  browsers perform when resolving `href` attributes against the current
+  document URL.
+
+  The base must be an absolute URI (must have a scheme). Returns
+  `BaseURINotAbsolute` if the base lacks a scheme.
+  """
+  fun apply(base: URI val, reference: URI val)
+    : (URI val | ResolveURIError val)
+  =>
+    """
+    Resolve `reference` against `base` using the algorithm from RFC 3986
+    section 5.2.2. The base must have a scheme; the reference may be any
+    URI-reference (absolute or relative).
+    """
+    let base_scheme = match base.scheme
+    | let s: String => s
+    | None => return BaseURINotAbsolute
+    end
+
+    match reference.scheme
+    | let r_scheme: String =>
+      // Reference has scheme — use it entirely (with dot-segment removal)
+      URI(r_scheme, reference.authority,
+        RemoveDotSegments(reference.path),
+        reference.query, reference.fragment)
+    else
+      match reference.authority
+      | let r_auth: URIAuthority =>
+        // Reference has authority — inherit base scheme only
+        URI(base_scheme, r_auth,
+          RemoveDotSegments(reference.path),
+          reference.query, reference.fragment)
+      else
+        if reference.path == "" then
+          // Empty path — inherit base path; inherit base query only when
+          // the reference has no query at all
+          let q: (String | None) = match reference.query
+          | let rq: String => rq
+          else
+            base.query
+          end
+          URI(base_scheme, base.authority, base.path,
+            q, reference.fragment)
+        else
+          // Non-empty relative path
+          let resolved_path = try
+            if reference.path(0)? == '/' then
+              // Absolute path — use directly with dot-segment removal
+              RemoveDotSegments(reference.path)
+            else
+              // Relative path — merge with base then remove dot segments
+              RemoveDotSegments(_merge(base, reference.path))
+            end
+          else
+            _Unreachable()
+            ""
+          end
+          URI(base_scheme, base.authority, resolved_path,
+            reference.query, reference.fragment)
+        end
+      end
+    end
+
+  fun _merge(base: URI val, ref_path: String val): String val =>
+    """
+    RFC 3986 section 5.2.3: merge a relative-path reference with a base URI.
+    """
+    match base.authority
+    | let _: URIAuthority =>
+      if base.path == "" then
+        // Base has authority and empty path — prepend "/"
+        return "/" + ref_path
+      end
+    end
+    // Take base path up to and including last "/", append reference path
+    try
+      var i = base.path.size()
+      while i > 0 do
+        i = i - 1
+        if base.path(i)? == '/' then
+          return base.path.substring(0, (i + 1).isize()) + ref_path
+        end
+      end
+    else
+      _Unreachable()
+    end
+    // No "/" in base path — reference path stands alone
+    ref_path
+
+primitive BaseURINotAbsolute is Stringable
+  """
+  The base URI passed to `ResolveURI` does not have a scheme.
+
+  RFC 3986 section 5.2.2 requires the base URI to be an absolute URI.
+  A relative reference cannot serve as a resolution base.
+  """
+  fun string(): String iso^ => "BaseURINotAbsolute".clone()
+
+// ResolveURIError is any error returned by ResolveURI. Separate from
+// URIParseError — resolution errors are semantically distinct from parse
+// errors.
+type ResolveURIError is BaseURINotAbsolute

--- a/uri/uri.pony
+++ b/uri/uri.pony
@@ -1,7 +1,8 @@
 """
-# URI Parsing (RFC 3986)
+# URI Parsing and Resolution (RFC 3986)
 
-This package parses URI-references into structured components per RFC 3986.
+This package parses URI-references into structured components and resolves
+relative references against base URIs per RFC 3986.
 
 ## Entry Points
 
@@ -13,6 +14,19 @@ request-targets):
 match ParseURI("/index.html?page=1")
 | let u: URI val => // u.path, u.query, etc.
 | let e: URIParseError val => // handle error
+end
+```
+
+Use `ResolveURI` to resolve a relative reference against a base URI
+(RFC 3986 section 5):
+
+```pony
+match (ParseURI("http://example.com/a/b"), ParseURI("../c"))
+| (let base: URI val, let ref': URI val) =>
+  match ResolveURI(base, ref')
+  | let target: URI val => // target.string() == "http://example.com/a/c"
+  | let e: ResolveURIError val => // base was not absolute
+  end
 end
 ```
 
@@ -31,8 +45,8 @@ it returns a `QueryParams` collection with `get()`, `get_all()`, and
 `contains()` methods for key-based lookup. Use `ParseQueryParameters`
 directly on the `query` field when you need to distinguish "no query"
 from "invalid percent-encoding." Use `PercentDecode`/`PercentEncode`
-for encoding operations, and `PathSegments` for decoded path segment
-access.
+for encoding operations, `PathSegments` for decoded path segment access,
+and `RemoveDotSegments` for standalone path normalization.
 
 For URI template expansion (RFC 6570), use the `uri/template` subpackage.
 


### PR DESCRIPTION
Implements the RFC 3986 section 5 reference resolution algorithm — combining a base URI with a relative reference to produce a target URI.

New public API:
- `ResolveURI` — resolves a reference against an absolute base URI
- `RemoveDotSegments` — normalizes `.` and `..` segments in a URI path
- `BaseURINotAbsolute` / `ResolveURIError` — error when base lacks a scheme

Tests include 3 property tests for `RemoveDotSegments`, 5 property tests for `ResolveURI`, the complete RFC 5.4 test suite (sections 5.4.1 and 5.4.2), and additional edge cases.