### PR TITLE
Add URI normalization and equivalence per RFC 3986 section 6

### DIFF
--- a/.release-notes/add-uri-normalization.md
+++ b/.release-notes/add-uri-normalization.md
@@ -1,0 +1,30 @@
+## Add URI normalization and equivalence per RFC 3986 section 6
+
+Normalize URIs using syntax-based (section 6.2.2) and scheme-based (section 6.2.3) rules: lowercase scheme and host, normalize percent-encoding, remove dot segments, strip default ports (http→80, https→443, ftp→21), and set empty paths to `/` for http/https with authority.
+
+```pony
+match ParseURI("HTTP://Example.COM:80/%7Euser/a/../b?q=%6A")
+| let u: URI val =>
+  match NormalizeURI(u)
+  | let n: URI val =>
+    // n.string() == "http://example.com/~user/b?q=j"
+  end
+end
+```
+
+Test equivalence of two URIs under normalization:
+
+```pony
+match (ParseURI("HTTP://Example.COM:80/path"), ParseURI("http://example.com/path"))
+| (let a: URI val, let b: URI val) =>
+  match URIEquivalent(a, b)
+  | let eq: Bool =>
+    // eq == true
+  end
+end
+```
+
+New API:
+
+- `NormalizeURI` — applies syntax-based and scheme-based normalization
+- `URIEquivalent` — normalizes two URIs and compares them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ make clean              # clean build artifacts + corral cache
 **Implemented features**:
 - URI parsing according to RFC 3986 (scheme, authority, path, query, fragment)
 - URI reference resolution according to RFC 3986 section 5
+- URI normalization per RFC 3986 section 6 (syntax-based and scheme-based)
 - URI template expansion according to RFC 6570 (all 4 levels)
 
 **Planned features**:
@@ -30,8 +31,8 @@ Two packages: `uri` for RFC 3986 parsing, `uri/template` for RFC 6570 template e
 
 ### `uri` Package — RFC 3986 Parsing
 
-- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `ResolveURI`, `ResolveURIError` (`BaseURINotAbsolute`), `RemoveDotSegments`, `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`
-- **Internal**: `_Unreachable` for unreachable code paths
+- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `ResolveURI`, `ResolveURIError` (`BaseURINotAbsolute`), `NormalizeURI`, `URIEquivalent`, `RemoveDotSegments`, `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`
+- **Internal**: `_Unreachable` for unreachable code paths, `_NormalizePercentEncoding` for percent-encoding normalization, `_SchemeDefaultPort` for default port lookup
 
 ### `uri/template` Package — RFC 6570 Template Expansion
 

--- a/examples/parsing/main.pony
+++ b/examples/parsing/main.pony
@@ -121,6 +121,49 @@ actor Main
       env.out.print("Parse error: " + e.string())
     end
 
+    env.out.print("")
+
+    // URI normalization (RFC 3986 section 6)
+    env.out.print("URI Normalization (RFC 3986 Section 6)")
+    env.out.print("======================================")
+    env.out.print("")
+
+    let raw = "HTTP://Example.COM:80/%7Euser/a/../b?q=%6A"
+    match ParseURI(raw)
+    | let u: URI val =>
+      match NormalizeURI(u)
+      | let n: URI val =>
+        env.out.print("  Original:   " + raw)
+        env.out.print("  Normalized: " + n.string())
+      | let e: InvalidPercentEncoding val =>
+        env.out.print("  Normalization error: " + e.string())
+      end
+    | let e: URIParseError val =>
+      env.out.print("  Parse error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // URI equivalence
+    env.out.print("URI Equivalence")
+    env.out.print("===============")
+    env.out.print("")
+
+    let eq_a = "http://EXAMPLE.COM:80/path"
+    let eq_b = "http://example.com/path"
+    match (ParseURI(eq_a), ParseURI(eq_b))
+    | (let a: URI val, let b: URI val) =>
+      match URIEquivalent(a, b)
+      | let result: Bool =>
+        env.out.print("  " + eq_a + " == " + eq_b + "? "
+          + result.string())
+      | let e: InvalidPercentEncoding val =>
+        env.out.print("  Equivalence error: " + e.string())
+      end
+    else
+      env.out.print("  Parse error")
+    end
+
   fun _resolve(env: Env, base: URI val, reference_str: String) =>
     match ParseURI(reference_str)
     | let reference: URI val =>

--- a/uri/_normalize_percent_encoding.pony
+++ b/uri/_normalize_percent_encoding.pony
@@ -1,0 +1,45 @@
+primitive _NormalizePercentEncoding
+  """
+  Normalize percent-encoded sequences in a URI component string.
+
+  For each `%XX` sequence: if the decoded byte is an unreserved character
+  (RFC 3986 section 2.3), emit the literal character; otherwise emit the
+  `%XX` triplet with uppercase hex digits. Non-percent characters pass
+  through unchanged.
+
+  Returns `InvalidPercentEncoding` for truncated sequences (`%` or `%A`
+  at end of string) or non-hex digits after `%`.
+  """
+  fun apply(input: String val): (String val | InvalidPercentEncoding val) =>
+    // Fast path: no percent signs means nothing to normalize
+    if not input.contains("%") then
+      return input
+    end
+
+    let out = String(input.size())
+    var i: USize = 0
+    while i < input.size() do
+      try
+        let c = input(i)?
+        if c == '%' then
+          if (i + 2) >= input.size() then
+            return InvalidPercentEncoding
+          end
+          let hi = PercentDecode._hex_value(input(i + 1)?)?
+          let lo = PercentDecode._hex_value(input(i + 2)?)?
+          let byte = (hi * 16) + lo
+          if PercentEncode._is_unreserved(byte) then
+            out.push(byte)
+          else
+            out.append(PercentEncode._encode_byte(byte))
+          end
+          i = i + 3
+        else
+          out.push(c)
+          i = i + 1
+        end
+      else
+        return InvalidPercentEncoding
+      end
+    end
+    out.clone()

--- a/uri/_test.pony
+++ b/uri/_test.pony
@@ -70,3 +70,29 @@ actor \nodoc\ Main is TestList
     test(_TestResolveURIRFCNormal)
     test(_TestResolveURIRFCAbnormal)
     test(_TestResolveURIEdgeCases)
+
+    // NormalizeURI tests
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeIdempotent))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeSchemeLowercase))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeHostLowercase))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeNoEncodedUnreserved))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeUppercaseHex))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeNoDotSegments))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeParseRoundtrip))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeNoDefaultPort))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeNoEmptyPathWithAuthority))
+    test(Property1UnitTest[(_NormalizableURIInput, _NormalizableURIInput)](
+      _PropertyNormalizeEquivalentConsistent))
+    test(Property1UnitTest[String val](
+      _PropertyNormalizeInvalidPercentRejected))
+    test(_TestNormalizeURIKnownGood)
+    test(_TestURIEquivalentKnownGood)

--- a/uri/_test_normalize_uri.pony
+++ b/uri/_test_normalize_uri.pony
@@ -1,0 +1,721 @@
+use "pony_test"
+use "pony_check"
+
+// -- Property-based tests --
+
+class \nodoc\ iso _PropertyNormalizeIdempotent
+  is Property1[_NormalizableURIInput]
+  """
+  Normalizing an already-normalized URI produces the same URI.
+  """
+  fun name(): String => "uri/normalize_uri/idempotent"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    let uri = arg1.uri
+    match NormalizeURI(uri)
+    | let once: URI val =>
+      match NormalizeURI(once)
+      | let twice: URI val =>
+        ph.assert_true(once == twice,
+          "not idempotent: once=" + once.string()
+            + " twice=" + twice.string()
+            + " original=" + uri.string())
+      | let e: InvalidPercentEncoding val =>
+        ph.fail("second normalization failed for: " + once.string())
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("first normalization failed for: " + uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeSchemeLowercase
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, the scheme contains no uppercase ASCII.
+  """
+  fun name(): String => "uri/normalize_uri/scheme_lowercase"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      match u.scheme
+      | let s: String =>
+        ph.assert_true(
+          not _HasUpperASCII(s),
+          "scheme has uppercase: " + s)
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeHostLowercase
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, non-percent-encoded characters in host have no
+  uppercase ASCII.
+  """
+  fun name(): String => "uri/normalize_uri/host_lowercase"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      match u.authority
+      | let a: URIAuthority =>
+        ph.assert_true(
+          not _HasUpperASCIIOutsidePercent(a.host),
+          "host has uppercase outside percent: " + a.host)
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeNoEncodedUnreserved
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, no %XX sequence decodes to an unreserved character.
+  """
+  fun name(): String => "uri/normalize_uri/no_encoded_unreserved"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      _check_no_encoded_unreserved(ph, u.path, "path")
+      match u.authority
+      | let a: URIAuthority =>
+        _check_no_encoded_unreserved(ph, a.host, "host")
+        match a.userinfo
+        | let ui: String =>
+          _check_no_encoded_unreserved(ph, ui, "userinfo")
+        end
+      end
+      match u.query
+      | let q: String =>
+        _check_no_encoded_unreserved(ph, q, "query")
+      end
+      match u.fragment
+      | let f: String =>
+        _check_no_encoded_unreserved(ph, f, "fragment")
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+  fun _check_no_encoded_unreserved(
+    ph: PropertyHelper,
+    s: String val,
+    label: String)
+  =>
+    var i: USize = 0
+    while i < s.size() do
+      try
+        if s(i)? == '%' then
+          if (i + 2) < s.size() then
+            let hi = PercentDecode._hex_value(s(i + 1)?)?
+            let lo = PercentDecode._hex_value(s(i + 2)?)?
+            let byte = (hi * 16) + lo
+            ph.assert_false(
+              PercentEncode._is_unreserved(byte),
+              label + " has encoded unreserved char: "
+                + s.substring(i.isize(), (i + 3).isize()))
+          end
+          i = i + 3
+        else
+          i = i + 1
+        end
+      else
+        return
+      end
+    end
+
+class \nodoc\ iso _PropertyNormalizeUppercaseHex
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, all %XX sequences use uppercase hex digits.
+  """
+  fun name(): String => "uri/normalize_uri/uppercase_hex"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      _check_uppercase_hex(ph, u.path, "path")
+      match u.authority
+      | let a: URIAuthority =>
+        _check_uppercase_hex(ph, a.host, "host")
+        match a.userinfo
+        | let ui: String =>
+          _check_uppercase_hex(ph, ui, "userinfo")
+        end
+      end
+      match u.query
+      | let q: String =>
+        _check_uppercase_hex(ph, q, "query")
+      end
+      match u.fragment
+      | let f: String =>
+        _check_uppercase_hex(ph, f, "fragment")
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+  fun _check_uppercase_hex(
+    ph: PropertyHelper,
+    s: String val,
+    label: String)
+  =>
+    var i: USize = 0
+    while i < s.size() do
+      try
+        if s(i)? == '%' then
+          if (i + 2) < s.size() then
+            let h1 = s(i + 1)?
+            let h2 = s(i + 2)?
+            ph.assert_false(
+              ((h1 >= 'a') and (h1 <= 'f'))
+                or ((h2 >= 'a') and (h2 <= 'f')),
+              label + " has lowercase hex: "
+                + s.substring(i.isize(), (i + 3).isize()))
+          end
+          i = i + 3
+        else
+          i = i + 1
+        end
+      else
+        return
+      end
+    end
+
+class \nodoc\ iso _PropertyNormalizeNoDotSegments
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, the path has no dot segments.
+  """
+  fun name(): String => "uri/normalize_uri/no_dot_segments"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      let path = u.path
+      ph.assert_eq[String val](
+        RemoveDotSegments(path), path,
+        "path still has dot segments: " + path
+          + " from: " + arg1.uri.string())
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeParseRoundtrip
+  is Property1[_NormalizableURIInput]
+  """
+  Parsing the string form of a normalized URI produces an equal URI.
+  """
+  fun name(): String => "uri/normalize_uri/parse_roundtrip"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let normalized: URI val =>
+      match ParseURI(normalized.string())
+      | let reparsed: URI val =>
+        ph.assert_true(normalized == reparsed,
+          "roundtrip failed: normalized=" + normalized.string()
+            + " reparsed=" + reparsed.string())
+      | let e: URIParseError val =>
+        ph.fail("reparse failed for: " + normalized.string()
+          + " error: " + e.string())
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeNoDefaultPort
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, if the scheme has a known default port, the port
+  is not that default.
+  """
+  fun name(): String => "uri/normalize_uri/no_default_port"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      match u.scheme
+      | let scheme: String =>
+        match _SchemeDefaultPort(scheme)
+        | let default_port: U16 =>
+          match u.authority
+          | let a: URIAuthority =>
+            match a.port
+            | let p: U16 =>
+              ph.assert_false(p == default_port,
+                "default port " + default_port.string()
+                  + " not removed for scheme " + scheme)
+            end
+          end
+        end
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeNoEmptyPathWithAuthority
+  is Property1[_NormalizableURIInput]
+  """
+  After normalization, if the scheme is http or https and authority is
+  present, the path is not empty.
+  """
+  fun name(): String => "uri/normalize_uri/no_empty_path_with_authority"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    match NormalizeURI(arg1.uri)
+    | let u: URI val =>
+      match u.scheme
+      | let scheme: String =>
+        if (scheme == "http") or (scheme == "https") then
+          match u.authority
+          | let _: URIAuthority =>
+            ph.assert_false(u.path == "",
+              "empty path with authority for " + scheme + ": "
+                + u.string())
+          end
+        end
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("normalization failed: " + arg1.uri.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeEquivalentConsistent
+  is Property1[(_NormalizableURIInput, _NormalizableURIInput)]
+  """
+  URIEquivalent(a, b) is consistent with NormalizeURI(a) == NormalizeURI(b).
+  """
+  fun name(): String => "uri/normalize_uri/equivalent_consistent"
+
+  fun gen(): Generator[(_NormalizableURIInput, _NormalizableURIInput)] =>
+    Generators.zip2[_NormalizableURIInput, _NormalizableURIInput](
+      _NormalizableURIInputGenerator(),
+      _NormalizableURIInputGenerator())
+
+  fun ref property(
+    arg1: (_NormalizableURIInput, _NormalizableURIInput),
+    ph: PropertyHelper)
+  =>
+    (let a_in, let b_in) = arg1
+    let a = a_in.uri
+    let b = b_in.uri
+    match (NormalizeURI(a), NormalizeURI(b))
+    | (let norm_a: URI val, let norm_b: URI val) =>
+      let expected = norm_a == norm_b
+      match URIEquivalent(a, b)
+      | let actual: Bool =>
+        ph.assert_eq[Bool](expected, actual,
+          "equivalent inconsistent: a=" + a.string()
+            + " b=" + b.string()
+            + " norm_a=" + norm_a.string()
+            + " norm_b=" + norm_b.string())
+      | let e: InvalidPercentEncoding val =>
+        ph.fail("URIEquivalent failed: " + a.string()
+          + " vs " + b.string())
+      end
+    | (let _: InvalidPercentEncoding val, _) =>
+      ph.fail("normalization failed for a: " + a.string())
+    | (_, let _: InvalidPercentEncoding val) =>
+      ph.fail("normalization failed for b: " + b.string())
+    end
+
+class \nodoc\ iso _PropertyNormalizeInvalidPercentRejected
+  is Property1[String val]
+  """
+  URIs with malformed percent-encoding produce InvalidPercentEncoding.
+  """
+  fun name(): String => "uri/normalize_uri/invalid_percent_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "http://example.com/path%GG"
+      "http://example.com/path%0"
+      "http://example.com/path%"
+      "http://example.com/%ZZfoo"
+      "http://example.com/path?q=%X1"
+      "http://example.com/path#frag%"
+      "http://user%info@example.com/path"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let u: URI val =>
+      match NormalizeURI(u)
+      | let _: URI val =>
+        ph.fail("expected InvalidPercentEncoding for: " + arg1)
+      | let _: InvalidPercentEncoding val =>
+        ph.assert_true(true)
+      end
+    | let _: URIParseError val =>
+      // Parse error is also acceptable — input is malformed
+      ph.assert_true(true)
+    end
+
+// -- Known-good example tests --
+
+class \nodoc\ iso _TestNormalizeURIKnownGood is UnitTest
+  """
+  Known-good normalization examples from RFC 3986 section 6.2.2 and 6.2.3.
+  """
+  fun name(): String => "uri/normalize_uri/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // -- 6.2.2 Syntax-based normalization --
+
+    // Case normalization (scheme + host)
+    _assert_normalize(h,
+      "HTTP://Example.COM/", "http://example.com/")
+
+    // Percent-encoding normalization (unreserved decoded)
+    _assert_normalize(h,
+      "http://example.com/%7Euser", "http://example.com/~user")
+
+    // Dot-segment removal
+    _assert_normalize(h,
+      "http://example.com/a/../b", "http://example.com/b")
+
+    // Percent-encoded dot segments decoded then removed
+    _assert_normalize(h,
+      "http://example.com/%2E%2E/b", "http://example.com/b")
+
+    // Query percent-encoding normalization
+    _assert_normalize(h,
+      "http://example.com/path?q=%6A", "http://example.com/path?q=j")
+
+    // Already-normalized URI unchanged
+    _assert_normalize(h,
+      "http://example.com/path", "http://example.com/path")
+
+    // Relative reference (no scheme) — scheme normalization skipped
+    _assert_normalize(h,
+      "/A/../b/%7Epath", "/b/~path")
+
+    // IP-literal host lowercased
+    _assert_normalize(h,
+      "http://[FE80::1]/", "http://[fe80::1]/")
+
+    // -- 6.2.3 Scheme-based normalization --
+
+    // Default port removal: http
+    _assert_normalize(h,
+      "http://example.com:80/", "http://example.com/")
+
+    // Default port removal: https
+    _assert_normalize(h,
+      "https://example.com:443/", "https://example.com/")
+
+    // Default port removal: ftp
+    _assert_normalize(h,
+      "ftp://example.com:21/", "ftp://example.com/")
+
+    // Non-default port kept
+    _assert_normalize(h,
+      "http://example.com:8080/", "http://example.com:8080/")
+
+    // Unknown scheme — port kept even if it matches a known default
+    _assert_normalize(h,
+      "unknown://example.com:80/", "unknown://example.com:80/")
+
+    // Empty path with authority → "/" (http)
+    _assert_normalize(h,
+      "http://example.com", "http://example.com/")
+
+    // Empty path with query → "/" inserted (http)
+    _assert_normalize(h,
+      "http://example.com?query", "http://example.com/?query")
+
+    // ftp: empty path NOT normalized to "/"
+    _assert_normalize(h,
+      "ftp://example.com", "ftp://example.com")
+
+    // -- Combined 6.2.2 + 6.2.3 --
+    _assert_normalize(h,
+      "HTTP://Example.COM:80/%7Euser/a/../b?q=%6A",
+      "http://example.com/~user/b?q=j")
+
+  fun _assert_normalize(
+    h: TestHelper,
+    input: String,
+    expected: String)
+  =>
+    match ParseURI(input)
+    | let u: URI val =>
+      match NormalizeURI(u)
+      | let normalized: URI val =>
+        h.assert_eq[String val](expected, normalized.string(),
+          "NormalizeURI(" + input + ")")
+      | let e: InvalidPercentEncoding val =>
+        h.fail("normalization failed for " + input + ": " + e.string())
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for " + input + ": " + e.string())
+    end
+
+class \nodoc\ iso _TestURIEquivalentKnownGood is UnitTest
+  """
+  Known-good equivalence comparisons.
+  """
+  fun name(): String => "uri/uri_equivalent/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Equivalent: case + default port
+    _assert_equivalent(h,
+      "HTTP://Example.COM:80/path", "http://example.com/path", true)
+
+    // Not equivalent: different paths
+    _assert_equivalent(h,
+      "http://example.com/a", "http://example.com/b", false)
+
+    // Reflexive: any URI equivalent to itself
+    _assert_equivalent(h,
+      "http://example.com/path?q=1#frag",
+      "http://example.com/path?q=1#frag", true)
+
+  fun _assert_equivalent(
+    h: TestHelper,
+    a_str: String,
+    b_str: String,
+    expected: Bool)
+  =>
+    match (ParseURI(a_str), ParseURI(b_str))
+    | (let a: URI val, let b: URI val) =>
+      match URIEquivalent(a, b)
+      | let result: Bool =>
+        h.assert_eq[Bool](expected, result,
+          "URIEquivalent(" + a_str + ", " + b_str + ")")
+      | let e: InvalidPercentEncoding val =>
+        h.fail("equivalence failed for (" + a_str + ", " + b_str
+          + "): " + e.string())
+      end
+    else
+      h.fail("parse failed for (" + a_str + ", " + b_str + ")")
+    end
+
+// -- Helpers --
+
+primitive _HasUpperASCII
+  """Check if a string contains any uppercase ASCII letter."""
+  fun apply(s: String val): Bool =>
+    for c in s.values() do
+      if (c >= 'A') and (c <= 'Z') then
+        return true
+      end
+    end
+    false
+
+primitive _HasUpperASCIIOutsidePercent
+  """
+  Check if a string contains uppercase ASCII letters outside of %XX
+  sequences. Hex digits within percent triplets are allowed to be
+  uppercase (that's the normalized form).
+  """
+  fun apply(s: String val): Bool =>
+    var i: USize = 0
+    while i < s.size() do
+      try
+        let c = s(i)?
+        if c == '%' then
+          // Skip the percent triplet
+          i = i + 3
+        elseif (c >= 'A') and (c <= 'Z') then
+          return true
+        else
+          i = i + 1
+        end
+      else
+        return false
+      end
+    end
+    false
+
+// -- Generators --
+
+class \nodoc\ val _NormalizableURIInput
+  let uri: URI val
+
+  new val create(uri': URI val) =>
+    uri = uri'
+
+primitive _NormalizableURIInputGenerator
+  """
+  Generate URIs suitable for normalization testing. All percent-encoding
+  is syntactically valid. Components may have mixed case, percent-encoded
+  unreserved characters, and dot segments — all things normalization
+  should fix.
+  """
+  fun apply(): Generator[_NormalizableURIInput] =>
+    Generators.map4[
+      (String val | None),
+      _NormAuthority,
+      _NormPathQueryFrag,
+      _NormPathQueryFrag,
+      _NormalizableURIInput](
+      _scheme_gen(),
+      _authority_gen(),
+      _path_query_frag_gen(),
+      _path_query_frag_gen(),
+      {(scheme, auth, pqf1, pqf2) =>
+        // Build a URI string from components and parse it
+        let out = recover iso String(128) end
+        match scheme
+        | let s: String => out.append(s); out.push(':')
+        end
+        match auth.value
+        | let a: String => out.append("//"); out.append(a)
+        end
+        out.append(pqf1.path)
+        match pqf1.query
+        | let q: String => out.push('?'); out.append(q)
+        end
+        match pqf2.query
+        | let f: String => out.push('#'); out.append(f)
+        end
+        let uri_str: String val = consume out
+        match ParseURI(uri_str)
+        | let u: URI val => _NormalizableURIInput(u)
+        else
+          // Fallback: should not happen since inputs are valid
+          _NormalizableURIInput(
+            URI(None, None, "/fallback", None, None))
+        end
+      })
+
+  fun _scheme_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (1, Generators.unit[(String val | None)](None))
+      (3, Generators.one_of[String val](
+        ["HTTP"; "Http"; "https"; "FTP"; "Scheme"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _authority_gen(): Generator[_NormAuthority] =>
+    Generators.map2[
+      (String val | None),
+      _NormHostPort,
+      _NormAuthority](
+      _userinfo_gen(),
+      _host_port_gen(),
+      {(userinfo, host_port) =>
+        match host_port.value
+        | let hp: String =>
+          let auth = match userinfo
+          | let u: String => u + "@" + hp
+          else hp
+          end
+          _NormAuthority(auth)
+        else
+          _NormAuthority(None)
+        end
+      })
+
+  fun _userinfo_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (3, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["user"; "us%65r"; "user:pass"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _host_port_gen(): Generator[_NormHostPort] =>
+    Generators.map2[String val, (String val | None), _NormHostPort](
+      _host_gen(),
+      _port_gen(),
+      {(host, port) =>
+        match port
+        | let p: String => _NormHostPort(host + ":" + p)
+        else _NormHostPort(host)
+        end
+      })
+
+  fun _host_gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "EXAMPLE.COM"
+      "Example.Org"
+      "LOCALHOST"
+      "ex%61mple.com"
+      "[FE80::1]"
+      "192.168.1.1"
+    ])
+
+  fun _port_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["80"; "443"; "21"; "8080"; "3000"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _path_query_frag_gen(): Generator[_NormPathQueryFrag] =>
+    Generators.map2[String val, (String val | None), _NormPathQueryFrag](
+      _path_gen(),
+      _query_or_frag_gen(),
+      {(path, query) => _NormPathQueryFrag(path, query) })
+
+  fun _path_gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "/a/../b"
+      "/%7Epath"
+      "/a/%2E%2E/b"
+      "/normal/path"
+      ""
+      "/"
+      "/a/b/c"
+    ])
+
+  fun _query_or_frag_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["q=%6a"; "key=%7Eval"; "plain"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+// Helper types for generator composition
+
+class \nodoc\ val _NormAuthority
+  let value: (String | None)
+  new val create(value': (String | None)) => value = value'
+
+class \nodoc\ val _NormHostPort
+  let value: (String | None)
+  new val create(value': (String | None)) => value = value'
+
+class \nodoc\ val _NormPathQueryFrag
+  let path: String
+  let query: (String | None)
+  new val create(path': String, query': (String | None)) =>
+    path = path'
+    query = query'

--- a/uri/normalize_uri.pony
+++ b/uri/normalize_uri.pony
@@ -1,0 +1,133 @@
+primitive NormalizeURI
+  """
+  Normalize a URI per RFC 3986 sections 6.2.2 (syntax-based) and 6.2.3
+  (scheme-based).
+
+  Syntax-based normalization (always safe, uses only generic URI syntax):
+  - **Case normalization**: scheme and host are lowercased.
+  - **Percent-encoding normalization**: hex digits in `%XX` are uppercased;
+    percent-encoded unreserved characters are decoded to their literal form.
+  - **Dot-segment removal**: `.` and `..` segments are resolved in the path.
+
+  Scheme-based normalization (requires scheme-specific knowledge):
+  - **Default port removal**: ports matching the scheme's well-known default
+    (http→80, https→443, ftp→21) are removed.
+  - **Empty path normalization**: for `http` and `https`, an empty path with
+    an authority is set to `"/"` (per RFC 7230).
+
+  Returns `InvalidPercentEncoding` if any component contains a malformed
+  percent-encoded sequence, since `ParseURI` does not validate
+  percent-encoding within components.
+  """
+  fun apply(uri: URI val): (URI val | InvalidPercentEncoding val) =>
+    // -- 6.2.2: Syntax-based normalization --
+
+    // Lowercase scheme
+    let norm_scheme: (String | None) = match uri.scheme
+    | let s: String => s.lower()
+    | None => None
+    end
+
+    // Normalize authority
+    let norm_authority: (URIAuthority | None) = match uri.authority
+    | let a: URIAuthority =>
+      // Normalize userinfo percent-encoding
+      let norm_userinfo: (String | None) = match a.userinfo
+      | let u: String =>
+        match _NormalizePercentEncoding(u)
+        | let s: String => s
+        | let e: InvalidPercentEncoding val => return e
+        end
+      | None => None
+      end
+
+      // Lowercase host, then normalize percent-encoding
+      let lower_host: String val = a.host.lower()
+      let norm_host = match _NormalizePercentEncoding(lower_host)
+      | let s: String => s
+      | let e: InvalidPercentEncoding val => return e
+      end
+
+      URIAuthority(norm_userinfo, norm_host, a.port)
+    | None => None
+    end
+
+    // Normalize path: percent-encoding first, then dot-segment removal
+    let pct_path = match _NormalizePercentEncoding(uri.path)
+    | let s: String => s
+    | let e: InvalidPercentEncoding val => return e
+    end
+    let norm_path = RemoveDotSegments(pct_path)
+
+    // Normalize query percent-encoding
+    let norm_query: (String | None) = match uri.query
+    | let q: String =>
+      match _NormalizePercentEncoding(q)
+      | let s: String => s
+      | let e: InvalidPercentEncoding val => return e
+      end
+    | None => None
+    end
+
+    // Normalize fragment percent-encoding
+    let norm_fragment: (String | None) = match uri.fragment
+    | let f: String =>
+      match _NormalizePercentEncoding(f)
+      | let s: String => s
+      | let e: InvalidPercentEncoding val => return e
+      end
+    | None => None
+    end
+
+    // -- 6.2.3: Scheme-based normalization --
+    // Only applies when a scheme is present (not for relative references)
+    (let final_authority, let final_path) = match norm_scheme
+    | let scheme: String =>
+      // Default port removal
+      let scheme_authority = match norm_authority
+      | let a: URIAuthority =>
+        match (a.port, _SchemeDefaultPort(scheme))
+        | (let port: U16, let default_port: U16) if port == default_port =>
+          URIAuthority(a.userinfo, a.host, None)
+        else
+          a
+        end
+      | None => None
+      end
+
+      // Empty path normalization (http and https only)
+      let scheme_path = if (norm_path == "")
+        and (scheme_authority isnt None)
+        and ((scheme == "http") or (scheme == "https"))
+      then
+        "/"
+      else
+        norm_path
+      end
+
+      (scheme_authority, scheme_path)
+    else
+      (norm_authority, norm_path)
+    end
+
+    URI(norm_scheme, final_authority, final_path,
+      norm_query, norm_fragment)
+
+primitive _SchemeDefaultPort
+  """
+  Return the well-known default port for a URI scheme, or `None` for
+  unknown schemes.
+
+  The input scheme must already be lowercased (6.2.2 case normalization
+  runs before 6.2.3).
+  """
+  fun apply(scheme: String): (U16 | None) =>
+    if scheme == "http" then
+      80
+    elseif scheme == "https" then
+      443
+    elseif scheme == "ftp" then
+      21
+    else
+      None
+    end

--- a/uri/uri.pony
+++ b/uri/uri.pony
@@ -40,6 +40,31 @@ match ParseURIAuthority("example.com:443")
 end
 ```
 
+Use `NormalizeURI` to apply RFC 3986 section 6 normalization (case,
+percent-encoding, dot segments, default port removal, empty path):
+
+```pony
+match ParseURI("HTTP://Example.COM:80/%7Euser/a/../b")
+| let u: URI val =>
+  match NormalizeURI(u)
+  | let n: URI val => // n.string() == "http://example.com/~user/b"
+  | let e: InvalidPercentEncoding val => // malformed percent-encoding
+  end
+end
+```
+
+Use `URIEquivalent` to test whether two URIs are equivalent under
+normalization:
+
+```pony
+match (ParseURI("HTTP://Example.COM:80/path"), ParseURI("http://example.com/path"))
+| (let a: URI val, let b: URI val) =>
+  match URIEquivalent(a, b)
+  | let eq: Bool => // eq == true
+  end
+end
+```
+
 For query parameter access, `URI.query_params()` is the simplest path —
 it returns a `QueryParams` collection with `get()`, `get_all()`, and
 `contains()` methods for key-based lookup. Use `ParseQueryParameters`
@@ -75,7 +100,8 @@ class val URI is (Stringable & Equatable[URI])
 
   Equality is structural: two URIs are equal when all their stored
   (percent-encoded) components are equal. No normalization is applied
-  before comparison.
+  before comparison. Use `URIEquivalent` for normalization-aware
+  comparison (RFC 3986 section 6).
   """
   let scheme: (String | None)
   let authority: (URIAuthority | None)

--- a/uri/uri_equivalent.pony
+++ b/uri/uri_equivalent.pony
@@ -1,0 +1,25 @@
+primitive URIEquivalent
+  """
+  Test whether two URIs are equivalent under RFC 3986 normalization.
+
+  Normalizes both URIs via `NormalizeURI` (syntax-based and scheme-based)
+  and compares them with structural equality. This catches equivalences
+  that raw string or structural comparison would miss — for example,
+  `HTTP://Example.COM:80/path` and `http://example.com/path` are
+  equivalent.
+
+  Returns `InvalidPercentEncoding` if either URI contains a malformed
+  percent-encoded sequence.
+  """
+  fun apply(a: URI val, b: URI val)
+    : (Bool | InvalidPercentEncoding val)
+  =>
+    let norm_a = match NormalizeURI(a)
+    | let u: URI val => u
+    | let e: InvalidPercentEncoding val => return e
+    end
+    let norm_b = match NormalizeURI(b)
+    | let u: URI val => u
+    | let e: InvalidPercentEncoding val => return e
+    end
+    norm_a == norm_b


### PR DESCRIPTION
Implement syntax-based (6.2.2) and scheme-based (6.2.3) URI normalization and a normalization-aware equivalence comparison.

Syntax-based: lowercase scheme/host, normalize percent-encoding (uppercase hex digits, decode unreserved characters), remove dot segments. Scheme-based: remove default ports (http→80, https→443, ftp→21), set empty path to `/` for http/https with authority.

New public API: `NormalizeURI`, `URIEquivalent`. Returns `InvalidPercentEncoding` if any component has malformed percent-encoding.

13 new tests (11 property-based, 2 example-based) covering idempotency, case normalization, percent-encoding normalization, dot-segment removal, default port removal, empty path normalization, parse roundtrip, equivalence consistency, and invalid input rejection.