### PR TITLE
Add IRI support per RFC 3987

### DIFF
--- a/.release-notes/add-iri-support.md
+++ b/.release-notes/add-iri-support.md
@@ -1,0 +1,48 @@
+## Add IRI support per RFC 3987
+
+Add IRI (Internationalized Resource Identifier) support for working with URIs that contain Unicode characters. `ParseURI` and `ResolveURI` already handle IRIs natively — the new primitives handle conversion between IRI and URI forms, IRI-aware encoding, normalization, and equivalence.
+
+Convert between IRI and URI forms:
+
+```pony
+// IRI to URI — percent-encodes all non-ASCII bytes
+match ParseURI("http://example.com/café")
+| let iri: URI val =>
+  let uri = IRIToURI(iri)
+  // uri.string() == "http://example.com/caf%C3%A9"
+end
+
+// URI to IRI — decodes ucschar sequences back to literal UTF-8
+match ParseURI("http://example.com/caf%C3%A9")
+| let uri: URI val =>
+  let iri = URIToIRI(uri)
+  // iri.string() == "http://example.com/café"
+end
+```
+
+IRI-aware percent-encoding preserves Unicode characters that are allowed literally in IRIs:
+
+```pony
+IRIPercentEncode("café menu", URIPartPath)  // "café%20menu"
+PercentEncode("café menu", URIPartPath)     // "caf%C3%A9%20menu"
+```
+
+Detect equivalence across IRI and URI forms:
+
+```pony
+match (ParseURI("http://example.com/café"), ParseURI("http://example.com/caf%C3%A9"))
+| (let a: URI val, let b: URI val) =>
+  match IRIEquivalent(a, b)
+  | let eq: Bool =>
+    // eq == true
+  end
+end
+```
+
+New API:
+
+- `IRIToURI` — convert IRI to URI by percent-encoding non-ASCII bytes
+- `URIToIRI` — convert URI to IRI by decoding allowed non-ASCII sequences
+- `IRIPercentEncode` — IRI-aware encoding that preserves `ucschar` codepoints
+- `NormalizeIRI` — IRI-aware normalization (applies `NormalizeURI` then `URIToIRI`)
+- `IRIEquivalent` — equivalence testing across IRI and URI forms

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ make clean              # clean build artifacts + corral cache
 - URI parsing according to RFC 3986 (scheme, authority, path, query, fragment)
 - URI reference resolution according to RFC 3986 section 5
 - URI normalization per RFC 3986 section 6 (syntax-based and scheme-based)
+- IRI support per RFC 3987 (IRI/URI conversion, IRI-aware encoding, IRI normalization, IRI equivalence)
 - URI template expansion according to RFC 6570 (all 4 levels)
 
 **Planned features**:
@@ -31,8 +32,8 @@ Two packages: `uri` for RFC 3986 parsing, `uri/template` for RFC 6570 template e
 
 ### `uri` Package — RFC 3986 Parsing
 
-- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `ResolveURI`, `ResolveURIError` (`BaseURINotAbsolute`), `NormalizeURI`, `URIEquivalent`, `RemoveDotSegments`, `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`
-- **Internal**: `_Unreachable` for unreachable code paths, `_NormalizePercentEncoding` for percent-encoding normalization, `_SchemeDefaultPort` for default port lookup
+- **Public API**: `URI`, `URIAuthority`, `ParseURI`, `ParseURIAuthority`, `URIParseError` (`InvalidPort`, `InvalidHost`), `ResolveURI`, `ResolveURIError` (`BaseURINotAbsolute`), `NormalizeURI`, `URIEquivalent`, `RemoveDotSegments`, `PercentEncode`, `PercentDecode`, `InvalidPercentEncoding`, `URIPart` (+ 5 part primitives), `PathSegments`, `ParseQueryParameters`, `QueryParams`, `IRIToURI`, `URIToIRI`, `IRIPercentEncode`, `NormalizeIRI`, `IRIEquivalent`
+- **Internal**: `_Unreachable` for unreachable code paths, `_NormalizePercentEncoding` for percent-encoding normalization, `_SchemeDefaultPort` for default port lookup, `_IRIChars` for IRI codepoint classification
 
 ### `uri/template` Package — RFC 6570 Template Expansion
 

--- a/examples/iri/main.pony
+++ b/examples/iri/main.pony
@@ -1,0 +1,107 @@
+// in your code this `use` statement would be:
+// use "uri"
+use "../../uri"
+
+actor Main
+  """
+  Demonstrates IRI support (RFC 3987).
+  """
+  new create(env: Env) =>
+    env.out.print("IRI Examples (RFC 3987)")
+    env.out.print("=======================")
+    env.out.print("")
+
+    // ParseURI handles IRIs natively — non-ASCII bytes pass through
+    let iri_str = "http://example.com/r\xE9sum\xE9?q=caf\xE9#\xE9"
+    env.out.print("Parsing an IRI:")
+    match ParseURI(iri_str)
+    | let u: URI val =>
+      env.out.print("  Input:     " + iri_str)
+      env.out.print("  Parsed:    " + u.string())
+      env.out.print("  Path:      " + u.path)
+      match u.query
+      | let q: String => env.out.print("  Query:     " + q)
+      end
+      match u.fragment
+      | let f: String => env.out.print("  Fragment:  " + f)
+      end
+    | let e: URIParseError val =>
+      env.out.print("  Parse error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // Convert between IRI and URI forms
+    env.out.print("IRI to URI Conversion")
+    env.out.print("---------------------")
+    match ParseURI("http://example.com/caf\xE9")
+    | let iri: URI val =>
+      let uri = IRIToURI(iri)
+      env.out.print("  IRI: " + iri.string())
+      env.out.print("  URI: " + uri.string())
+    | let e: URIParseError val =>
+      env.out.print("  Error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // Convert URI back to IRI
+    env.out.print("URI to IRI Conversion")
+    env.out.print("---------------------")
+    match ParseURI("http://example.com/r%C3%A9sum%C3%A9")
+    | let uri: URI val =>
+      let iri = URIToIRI(uri)
+      env.out.print("  URI: " + uri.string())
+      env.out.print("  IRI: " + iri.string())
+    | let e: URIParseError val =>
+      env.out.print("  Error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // IRI-aware percent-encoding
+    env.out.print("IRI Percent-Encoding")
+    env.out.print("--------------------")
+    let raw = "caf\xE9 menu"
+    env.out.print("  Input:   " + raw)
+    env.out.print("  IRI:     " + IRIPercentEncode(raw, URIPartPath))
+    env.out.print("  URI:     " + PercentEncode(raw, URIPartPath))
+
+    env.out.print("")
+
+    // IRI normalization
+    env.out.print("IRI Normalization")
+    env.out.print("-----------------")
+    let unnormalized = "HTTP://Example.COM:80/r%C3%A9sum%C3%A9"
+    match ParseURI(unnormalized)
+    | let u: URI val =>
+      match NormalizeIRI(u)
+      | let n: URI val =>
+        env.out.print("  Original:   " + unnormalized)
+        env.out.print("  Normalized: " + n.string())
+      | let e: InvalidPercentEncoding val =>
+        env.out.print("  Error: " + e.string())
+      end
+    | let e: URIParseError val =>
+      env.out.print("  Error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // IRI equivalence — detects equivalence across IRI/URI forms
+    env.out.print("IRI Equivalence")
+    env.out.print("---------------")
+    let eq_a = "http://example.com/caf\xE9"
+    let eq_b = "http://example.com/caf%C3%A9"
+    match (ParseURI(eq_a), ParseURI(eq_b))
+    | (let a: URI val, let b: URI val) =>
+      match IRIEquivalent(a, b)
+      | let result: Bool =>
+        env.out.print("  " + eq_a + " == " + eq_b + "? "
+          + result.string())
+      | let e: InvalidPercentEncoding val =>
+        env.out.print("  Error: " + e.string())
+      end
+    else
+      env.out.print("  Parse error")
+    end

--- a/uri/_iri_chars.pony
+++ b/uri/_iri_chars.pony
@@ -1,0 +1,62 @@
+primitive _IRIChars
+  """
+  Codepoint classification for IRI characters per RFC 3987.
+
+  `ucschar` (section 2.2): allowed in IRI components except scheme.
+  `iprivate` (section 2.2): allowed only in the query component.
+  Bidi formatting characters: within the `ucschar` BMP range but
+  prohibited from appearing literally in IRIs (section 4.1).
+  """
+  fun is_ucschar(cp: U32): Bool =>
+    // RFC 3987 section 2.2:
+    //   ucschar = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
+    //           / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
+    //           / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
+    //           / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
+    //           / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
+    //           / %xD0000-DFFFD / %xE1000-EFFFD
+
+    // BMP ranges
+    if (cp >= 0xA0) and (cp <= 0xD7FF) then
+      return true
+    end
+    if (cp >= 0xF900) and (cp <= 0xFDCF) then
+      return true
+    end
+    if (cp >= 0xFDF0) and (cp <= 0xFFEF) then
+      return true
+    end
+
+    // Planes 1-13: each plane allows x0000-xFFFD (excludes xFFFE-xFFFF)
+    if (cp >= 0x10000) and (cp <= 0xDFFFD) then
+      return (cp and 0xFFFF) <= 0xFFFD
+    end
+
+    // Plane 14 partial: E1000-EFFFD
+    if (cp >= 0xE1000) and (cp <= 0xEFFFD) then
+      return true
+    end
+
+    false
+
+  fun is_iprivate(cp: U32): Bool =>
+    // RFC 3987 section 2.2:
+    //   iprivate = %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
+    if (cp >= 0xE000) and (cp <= 0xF8FF) then
+      return true
+    end
+    if (cp >= 0xF0000) and (cp <= 0xFFFFD) then
+      return true
+    end
+    if (cp >= 0x100000) and (cp <= 0x10FFFD) then
+      return true
+    end
+    false
+
+  fun is_bidi_format(cp: U32): Bool =>
+    // RFC 3987 section 4.1 prohibits these from appearing literally in IRIs:
+    //   U+200E (LRM), U+200F (RLM), U+202A-202E (LRE, RLE, PDF, LRO, RLO)
+    if (cp == 0x200E) or (cp == 0x200F) then
+      return true
+    end
+    (cp >= 0x202A) and (cp <= 0x202E)

--- a/uri/_test.pony
+++ b/uri/_test.pony
@@ -96,3 +96,24 @@ actor \nodoc\ Main is TestList
       _PropertyNormalizeInvalidPercentRejected))
     test(_TestNormalizeURIKnownGood)
     test(_TestURIEquivalentKnownGood)
+
+    // IRI tests (RFC 3987)
+    test(Property1UnitTest[String val](_PropertyIRIToURINoNonASCII))
+    test(Property1UnitTest[String val](_PropertyURIToIRINoEncodedUcschar))
+    test(Property1UnitTest[String val](_PropertyIRIToURIIdempotent))
+    test(Property1UnitTest[String val](_PropertyURIToIRIIdempotent))
+    test(Property1UnitTest[String val](_PropertyIRIToURIRoundtrip))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyNormalizeIRIIdempotent))
+    test(Property1UnitTest[_NormalizableURIInput](
+      _PropertyIRIEquivalentReflexive))
+    test(Property1UnitTest[String val](
+      _PropertyIRIEquivalentCrossForms))
+    test(Property1UnitTest[String val](
+      _PropertyIRIPercentEncodePreservesUcschar))
+    test(Property1UnitTest[String val](
+      _PropertyIRIPercentEncodeEncodesNonAllowed))
+    test(_TestIRICharsBoundary)
+    test(_TestIRIToURIKnownGood)
+    test(_TestURIToIRIKnownGood)
+    test(_TestNormalizeIRIKnownGood)

--- a/uri/_test_iri.pony
+++ b/uri/_test_iri.pony
@@ -1,0 +1,801 @@
+use "pony_test"
+use "pony_check"
+
+// ============================================================================
+// Property-based tests
+// ============================================================================
+
+class \nodoc\ iso _PropertyIRIToURINoNonASCII
+  is Property1[String val]
+  """
+  IRIToURI output has no literal non-ASCII bytes in any component.
+  """
+  fun name(): String => "uri/iri_to_uri/no_non_ascii"
+
+  fun gen(): Generator[String val] =>
+    _IRIStringGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let iri: URI val =>
+      let uri = IRIToURI(iri)
+      let uri_str: String val = uri.string()
+      for c in uri_str.values() do
+        if c >= 0x80 then
+          ph.fail("non-ASCII byte in IRIToURI output: " + uri_str
+            + " from: " + arg1)
+          return
+        end
+      end
+    | let _: URIParseError val => None
+    end
+
+class \nodoc\ iso _PropertyURIToIRINoEncodedUcschar
+  is Property1[String val]
+  """
+  URIToIRI output has no percent-encoded sequences that decode to ucschar.
+  """
+  fun name(): String => "uri/uri_to_iri/no_encoded_ucschar"
+
+  fun gen(): Generator[String val] =>
+    _URIWithEncodedNonASCIIGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let uri: URI val =>
+      let iri = URIToIRI(uri)
+      let iri_str: String val = iri.string()
+      _check_no_encoded_ucschar(ph, iri_str)
+    | let _: URIParseError val => None
+    end
+
+  fun _check_no_encoded_ucschar(
+    ph: PropertyHelper,
+    s: String val)
+  =>
+    var i: USize = 0
+    while i < s.size() do
+      try
+        if s(i)? == '%' then
+          if (i + 2) < s.size() then
+            let first_byte =
+              (PercentDecode._hex_value(s(i + 1)?)? * 16)
+                + PercentDecode._hex_value(s(i + 2)?)?
+            let seq_len = URIToIRI._utf8_sequence_length(first_byte)
+            if (seq_len > 1) and ((i + (seq_len * 3)) <= s.size()) then
+              let bytes = String(seq_len)
+              bytes.push(first_byte)
+              var j: USize = 1
+              var valid = true
+              while j < seq_len do
+                let offset = i + (j * 3)
+                if s(offset)? != '%' then
+                  valid = false
+                  break
+                end
+                bytes.push(
+                  (PercentDecode._hex_value(s(offset + 1)?)? * 16)
+                    + PercentDecode._hex_value(s(offset + 2)?)?)
+                j = j + 1
+              end
+              if valid and (bytes.size() == seq_len) then
+                try
+                  (let cp, let cp_len) = bytes.utf32(0)?
+                  if (cp_len.usize() == seq_len)
+                    and _IRIChars.is_ucschar(cp)
+                    and (not _IRIChars.is_bidi_format(cp))
+                  then
+                    ph.fail(
+                      "encoded ucschar U+"
+                        + _hex_u32(cp) + " in: " + s)
+                    return
+                  end
+                end
+              end
+            end
+          end
+          i = i + 3
+        else
+          i = i + 1
+        end
+      else
+        return
+      end
+    end
+
+  fun _hex_u32(cp: U32): String val =>
+    let hex = "0123456789ABCDEF"
+    recover val
+      let out = String(6)
+      if cp > 0xFFFF then
+        try
+          out.push(hex((cp >> 20).usize() and 0x0F)?)
+          out.push(hex((cp >> 16).usize() and 0x0F)?)
+        else _Unreachable() end
+      end
+      if cp > 0xFF then
+        try
+          out.push(hex((cp >> 12).usize() and 0x0F)?)
+          out.push(hex((cp >> 8).usize() and 0x0F)?)
+        else _Unreachable() end
+      end
+      try
+        out.push(hex((cp >> 4).usize() and 0x0F)?)
+        out.push(hex(cp.usize() and 0x0F)?)
+      else _Unreachable() end
+      out
+    end
+
+class \nodoc\ iso _PropertyIRIToURIIdempotent
+  is Property1[String val]
+  """
+  Applying IRIToURI twice produces the same result as once.
+  """
+  fun name(): String => "uri/iri_to_uri/idempotent"
+
+  fun gen(): Generator[String val] =>
+    _IRIStringGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let iri: URI val =>
+      let once = IRIToURI(iri)
+      let twice = IRIToURI(once)
+      ph.assert_true(once == twice,
+        "not idempotent: once=" + once.string()
+          + " twice=" + twice.string()
+          + " input=" + arg1)
+    | let _: URIParseError val => None
+    end
+
+class \nodoc\ iso _PropertyURIToIRIIdempotent
+  is Property1[String val]
+  """
+  Applying URIToIRI twice produces the same result as once.
+  """
+  fun name(): String => "uri/uri_to_iri/idempotent"
+
+  fun gen(): Generator[String val] =>
+    _URIWithEncodedNonASCIIGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let uri: URI val =>
+      let once = URIToIRI(uri)
+      let twice = URIToIRI(once)
+      ph.assert_true(once == twice,
+        "not idempotent: once=" + once.string()
+          + " twice=" + twice.string()
+          + " input=" + arg1)
+    | let _: URIParseError val => None
+    end
+
+class \nodoc\ iso _PropertyIRIToURIRoundtrip
+  is Property1[String val]
+  """
+  For IRIs containing only ucschar non-ASCII codepoints (no iprivate),
+  URIToIRI(IRIToURI(iri)) produces the original URI structure.
+  """
+  fun name(): String => "uri/iri/roundtrip"
+
+  fun gen(): Generator[String val] =>
+    _IRIUcscharOnlyGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let iri: URI val =>
+      let uri_form = IRIToURI(iri)
+      let back = URIToIRI(uri_form)
+      ph.assert_true(iri == back,
+        "roundtrip failed: original=" + iri.string()
+          + " uri=" + uri_form.string()
+          + " back=" + back.string())
+    | let _: URIParseError val => None
+    end
+
+class \nodoc\ iso _PropertyNormalizeIRIIdempotent
+  is Property1[_NormalizableURIInput]
+  """
+  Normalizing an already-normalized IRI produces the same IRI.
+  """
+  fun name(): String => "uri/normalize_iri/idempotent"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    let uri = arg1.uri
+    match NormalizeIRI(uri)
+    | let once: URI val =>
+      match NormalizeIRI(once)
+      | let twice: URI val =>
+        ph.assert_true(once == twice,
+          "not idempotent: once=" + once.string()
+            + " twice=" + twice.string()
+            + " original=" + uri.string())
+      | let e: InvalidPercentEncoding val =>
+        ph.fail("second normalization failed for: " + once.string())
+      end
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("first normalization failed for: " + uri.string())
+    end
+
+class \nodoc\ iso _PropertyIRIEquivalentReflexive
+  is Property1[_NormalizableURIInput]
+  """
+  Every valid URI/IRI is equivalent to itself.
+  """
+  fun name(): String => "uri/iri_equivalent/reflexive"
+
+  fun gen(): Generator[_NormalizableURIInput] =>
+    _NormalizableURIInputGenerator()
+
+  fun ref property(arg1: _NormalizableURIInput, ph: PropertyHelper) =>
+    let uri = arg1.uri
+    match IRIEquivalent(uri, uri)
+    | let result: Bool =>
+      ph.assert_true(result,
+        "not reflexive: " + uri.string())
+    | let e: InvalidPercentEncoding val =>
+      ph.fail("equivalence failed for: " + uri.string())
+    end
+
+class \nodoc\ iso _PropertyIRIEquivalentCrossForms
+  is Property1[String val]
+  """
+  An IRI and its URI form (via IRIToURI) are equivalent.
+  """
+  fun name(): String => "uri/iri_equivalent/cross_forms"
+
+  fun gen(): Generator[String val] =>
+    _IRIUcscharOnlyGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURI(arg1)
+    | let iri: URI val =>
+      let uri_form = IRIToURI(iri)
+      match IRIEquivalent(iri, uri_form)
+      | let result: Bool =>
+        ph.assert_true(result,
+          "IRI and URI form not equivalent: iri=" + iri.string()
+            + " uri=" + uri_form.string())
+      | let e: InvalidPercentEncoding val =>
+        ph.fail("equivalence failed: " + iri.string())
+      end
+    | let _: URIParseError val => None
+    end
+
+class \nodoc\ iso _PropertyIRIPercentEncodePreservesUcschar
+  is Property1[String val]
+  """
+  IRIPercentEncode preserves ucschar codepoints as literal UTF-8.
+  """
+  fun name(): String => "uri/iri_percent_encode/preserves_ucschar"
+
+  fun gen(): Generator[String val] =>
+    _UcscharStringGenerator()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let encoded = IRIPercentEncode(arg1, URIPartPath)
+    // Count non-ASCII codepoints in input and output — ucschar should
+    // survive as literal UTF-8, so the count must match.
+    let input_ucschar = _count_non_ascii_codepoints(arg1)
+    let output_ucschar = _count_non_ascii_codepoints(encoded)
+    ph.assert_eq[USize](input_ucschar, output_ucschar,
+      "ucschar count mismatch: input has " + input_ucschar.string()
+        + " non-ASCII codepoints but output has "
+        + output_ucschar.string()
+        + " input=" + arg1 + " output=" + encoded)
+
+  fun _count_non_ascii_codepoints(s: String val): USize =>
+    var count: USize = 0
+    var i: USize = 0
+    while i < s.size() do
+      try
+        let c = s(i)?
+        if c >= 0x80 then
+          (let cp, let cp_len) = s.utf32(i.isize())?
+          count = count + 1
+          i = i + cp_len.usize()
+        else
+          i = i + 1
+        end
+      else
+        return count
+      end
+    end
+    count
+
+class \nodoc\ iso _PropertyIRIPercentEncodeEncodesNonAllowed
+  is Property1[String val]
+  """
+  IRIPercentEncode encodes non-ASCII characters outside ucschar/iprivate.
+  """
+  fun name(): String => "uri/iri_percent_encode/encodes_non_allowed"
+
+  fun gen(): Generator[String val] =>
+    // Characters that should NOT appear literally in IRIs:
+    // U+0080-009F (between ASCII and ucschar start at U+00A0)
+    // U+200E-200F, U+202A-202E (bidi formatting — ucschar but prohibited)
+    Generators.one_of[String val]([
+      "\x80"    // U+0080 (control char)
+      "\x9F"    // U+009F (last control before ucschar)
+      "\u200E"  // U+200E (LRM — bidi formatting)
+      "\u200F"  // U+200F (RLM — bidi formatting)
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let encoded = IRIPercentEncode(arg1, URIPartPath)
+    // All non-ASCII bytes should be percent-encoded
+    for c in encoded.values() do
+      if c >= 0x80 then
+        ph.fail("non-ASCII byte in output for non-ucschar input: " + encoded
+          + " from: " + arg1)
+        return
+      end
+    end
+
+// ============================================================================
+// Example-based tests
+// ============================================================================
+
+class \nodoc\ iso _TestIRICharsBoundary is UnitTest
+  """
+  Boundary tests for _IRIChars codepoint classification.
+  """
+  fun name(): String => "uri/iri_chars/boundary"
+
+  fun ref apply(h: TestHelper) =>
+    // -- ucschar boundaries --
+    // U+009F just below range
+    h.assert_false(_IRIChars.is_ucschar(0x9F),
+      "U+009F should not be ucschar")
+    // U+00A0 start of range
+    h.assert_true(_IRIChars.is_ucschar(0xA0),
+      "U+00A0 should be ucschar")
+    // U+D7FF end of first BMP range
+    h.assert_true(_IRIChars.is_ucschar(0xD7FF),
+      "U+D7FF should be ucschar")
+    // U+D800 just past first BMP range (surrogate)
+    h.assert_false(_IRIChars.is_ucschar(0xD800),
+      "U+D800 should not be ucschar")
+
+    // U+F8FF just below second BMP range (private use)
+    h.assert_false(_IRIChars.is_ucschar(0xF8FF),
+      "U+F8FF should not be ucschar")
+    // U+F900 start of second BMP range
+    h.assert_true(_IRIChars.is_ucschar(0xF900),
+      "U+F900 should be ucschar")
+    // U+FDCF end of second BMP range
+    h.assert_true(_IRIChars.is_ucschar(0xFDCF),
+      "U+FDCF should be ucschar")
+    // U+FDD0 just past second BMP range (noncharacter)
+    h.assert_false(_IRIChars.is_ucschar(0xFDD0),
+      "U+FDD0 should not be ucschar")
+
+    // U+FDEF just below third BMP range
+    h.assert_false(_IRIChars.is_ucschar(0xFDEF),
+      "U+FDEF should not be ucschar")
+    // U+FDF0 start of third BMP range
+    h.assert_true(_IRIChars.is_ucschar(0xFDF0),
+      "U+FDF0 should be ucschar")
+    // U+FFEF end of third BMP range
+    h.assert_true(_IRIChars.is_ucschar(0xFFEF),
+      "U+FFEF should be ucschar")
+    // U+FFF0 just past third BMP range
+    h.assert_false(_IRIChars.is_ucschar(0xFFF0),
+      "U+FFF0 should not be ucschar")
+
+    // Planes 1-13 boundaries
+    // U+10000 start of plane 1
+    h.assert_true(_IRIChars.is_ucschar(0x10000),
+      "U+10000 should be ucschar")
+    // U+1FFFD end of plane 1
+    h.assert_true(_IRIChars.is_ucschar(0x1FFFD),
+      "U+1FFFD should be ucschar")
+    // U+1FFFE noncharacter in plane 1
+    h.assert_false(_IRIChars.is_ucschar(0x1FFFE),
+      "U+1FFFE should not be ucschar")
+    // U+1FFFF noncharacter in plane 1
+    h.assert_false(_IRIChars.is_ucschar(0x1FFFF),
+      "U+1FFFF should not be ucschar")
+    // U+DFFFD end of plane 13
+    h.assert_true(_IRIChars.is_ucschar(0xDFFFD),
+      "U+DFFFD should be ucschar")
+    // U+DFFFE noncharacter in plane 13
+    h.assert_false(_IRIChars.is_ucschar(0xDFFFE),
+      "U+DFFFE should not be ucschar")
+
+    // Plane 14 partial range
+    // U+E0FFF just below E1000
+    h.assert_false(_IRIChars.is_ucschar(0xE0FFF),
+      "U+E0FFF should not be ucschar")
+    // U+E1000 start
+    h.assert_true(_IRIChars.is_ucschar(0xE1000),
+      "U+E1000 should be ucschar")
+    // U+EFFFD end
+    h.assert_true(_IRIChars.is_ucschar(0xEFFFD),
+      "U+EFFFD should be ucschar")
+    // U+EFFFE just past
+    h.assert_false(_IRIChars.is_ucschar(0xEFFFE),
+      "U+EFFFE should not be ucschar")
+
+    // -- iprivate boundaries --
+    // U+DFFF just below private use
+    h.assert_false(_IRIChars.is_iprivate(0xDFFF),
+      "U+DFFF should not be iprivate")
+    // U+E000 start of BMP private use
+    h.assert_true(_IRIChars.is_iprivate(0xE000),
+      "U+E000 should be iprivate")
+    // U+F8FF end of BMP private use
+    h.assert_true(_IRIChars.is_iprivate(0xF8FF),
+      "U+F8FF should be iprivate")
+    // U+F900 just past BMP private use
+    h.assert_false(_IRIChars.is_iprivate(0xF900),
+      "U+F900 should not be iprivate")
+
+    // Plane 15
+    h.assert_true(_IRIChars.is_iprivate(0xF0000),
+      "U+F0000 should be iprivate")
+    h.assert_true(_IRIChars.is_iprivate(0xFFFFD),
+      "U+FFFFD should be iprivate")
+    h.assert_false(_IRIChars.is_iprivate(0xFFFFE),
+      "U+FFFFE should not be iprivate")
+
+    // Plane 16
+    h.assert_true(_IRIChars.is_iprivate(0x100000),
+      "U+100000 should be iprivate")
+    h.assert_true(_IRIChars.is_iprivate(0x10FFFD),
+      "U+10FFFD should be iprivate")
+    h.assert_false(_IRIChars.is_iprivate(0x10FFFE),
+      "U+10FFFE should not be iprivate")
+
+    // -- bidi format characters --
+    h.assert_true(_IRIChars.is_bidi_format(0x200E),
+      "U+200E should be bidi format")
+    h.assert_true(_IRIChars.is_bidi_format(0x200F),
+      "U+200F should be bidi format")
+    h.assert_true(_IRIChars.is_bidi_format(0x202A),
+      "U+202A should be bidi format")
+    h.assert_true(_IRIChars.is_bidi_format(0x202E),
+      "U+202E should be bidi format")
+    // Neighbors are not bidi format
+    h.assert_false(_IRIChars.is_bidi_format(0x200D),
+      "U+200D should not be bidi format")
+    h.assert_false(_IRIChars.is_bidi_format(0x2010),
+      "U+2010 should not be bidi format")
+    h.assert_false(_IRIChars.is_bidi_format(0x2029),
+      "U+2029 should not be bidi format")
+    h.assert_false(_IRIChars.is_bidi_format(0x202F),
+      "U+202F should not be bidi format")
+
+    // -- bidi chars are ucschar but should not be decoded --
+    h.assert_true(_IRIChars.is_ucschar(0x200E),
+      "U+200E is in ucschar range")
+    h.assert_true(_IRIChars.is_ucschar(0x200F),
+      "U+200F is in ucschar range")
+
+class \nodoc\ iso _TestIRIToURIKnownGood is UnitTest
+  """
+  Known-good IRIToURI conversions.
+  """
+  fun name(): String => "uri/iri_to_uri/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Pure ASCII unchanged
+    _assert_iri_to_uri(h,
+      "http://example.com/path?q=1#frag",
+      "http://example.com/path?q=1#frag")
+
+    // BMP ucschar encoded: é = U+00E9, UTF-8 bytes C3 A9
+    _assert_iri_to_uri(h,
+      "http://example.com/r\xE9sum\xE9",
+      "http://example.com/r%C3%A9sum%C3%A9")
+
+    // Supplementary plane character: U+1F600, UTF-8 bytes F0 9F 98 80
+    _assert_iri_to_uri(h,
+      "http://example.com/\U01F600",
+      "http://example.com/%F0%9F%98%80")
+
+    // Existing %XX triplets preserved
+    _assert_iri_to_uri(h,
+      "http://example.com/%20path",
+      "http://example.com/%20path")
+
+    // Mixed: literal non-ASCII + existing percent-encoding
+    _assert_iri_to_uri(h,
+      "http://example.com/caf\xE9/%20menu",
+      "http://example.com/caf%C3%A9/%20menu")
+
+    // Non-ASCII in host
+    _assert_iri_to_uri(h,
+      "http://\xE9xample.com/",
+      "http://%C3%A9xample.com/")
+
+    // Non-ASCII in query
+    _assert_iri_to_uri(h,
+      "http://example.com/?q=\xE9",
+      "http://example.com/?q=%C3%A9")
+
+    // Non-ASCII in fragment
+    _assert_iri_to_uri(h,
+      "http://example.com/#\xE9",
+      "http://example.com/#%C3%A9")
+
+  fun _assert_iri_to_uri(
+    h: TestHelper,
+    input: String,
+    expected: String)
+  =>
+    match ParseURI(input)
+    | let iri: URI val =>
+      let uri = IRIToURI(iri)
+      h.assert_eq[String val](expected, uri.string(),
+        "IRIToURI(" + input + ")")
+    | let e: URIParseError val =>
+      h.fail("parse failed for " + input + ": " + e.string())
+    end
+
+class \nodoc\ iso _TestURIToIRIKnownGood is UnitTest
+  """
+  Known-good URIToIRI conversions.
+  """
+  fun name(): String => "uri/uri_to_iri/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // ucschar decoded: é = U+00E9 = %C3%A9
+    _assert_uri_to_iri(h,
+      "http://example.com/r%C3%A9sum%C3%A9",
+      "http://example.com/r\xE9sum\xE9")
+
+    // iprivate decoded in query only: U+E000 = %EE%80%80
+    _assert_uri_to_iri(h,
+      "http://example.com/path?q=%EE%80%80",
+      "http://example.com/path?q=\uE000")
+
+    // iprivate NOT decoded in path
+    _assert_uri_to_iri(h,
+      "http://example.com/%EE%80%80",
+      "http://example.com/%EE%80%80")
+
+    // iprivate NOT decoded in fragment
+    _assert_uri_to_iri(h,
+      "http://example.com/#%EE%80%80",
+      "http://example.com/#%EE%80%80")
+
+    // Bidi chars stay encoded: U+200E = %E2%80%8E
+    _assert_uri_to_iri(h,
+      "http://example.com/%E2%80%8E",
+      "http://example.com/%E2%80%8E")
+
+    // Bidi chars stay encoded even in query: U+200F = %E2%80%8F
+    _assert_uri_to_iri(h,
+      "http://example.com/?q=%E2%80%8F",
+      "http://example.com/?q=%E2%80%8F")
+
+    // Invalid UTF-8 stays encoded (0xFF is not a valid leading byte)
+    _assert_uri_to_iri(h,
+      "http://example.com/%FF",
+      "http://example.com/%FF")
+
+    // Incomplete UTF-8 sequence stays encoded (C3 without continuation)
+    _assert_uri_to_iri(h,
+      "http://example.com/%C3",
+      "http://example.com/%C3")
+
+    // ASCII percent-encoding stays as-is
+    _assert_uri_to_iri(h,
+      "http://example.com/%20path",
+      "http://example.com/%20path")
+
+    // Pure ASCII unchanged
+    _assert_uri_to_iri(h,
+      "http://example.com/path",
+      "http://example.com/path")
+
+    // Supplementary plane ucschar decoded: U+10000 = %F0%90%80%80
+    _assert_uri_to_iri(h,
+      "http://example.com/%F0%90%80%80",
+      "http://example.com/\U010000")
+
+    // Lowercase hex digits handled
+    _assert_uri_to_iri(h,
+      "http://example.com/r%c3%a9sum%c3%a9",
+      "http://example.com/r\xE9sum\xE9")
+
+    // Non-ucschar, non-iprivate non-ASCII stays encoded
+    // U+009F = C2 9F — below ucschar range
+    _assert_uri_to_iri(h,
+      "http://example.com/%C2%9F",
+      "http://example.com/%C2%9F")
+
+    // Malformed percent-encoding (%GG) passes through unchanged
+    _assert_uri_to_iri(h,
+      "http://example.com/%GG",
+      "http://example.com/%GG")
+
+  fun _assert_uri_to_iri(
+    h: TestHelper,
+    input: String,
+    expected: String)
+  =>
+    match ParseURI(input)
+    | let uri: URI val =>
+      let iri = URIToIRI(uri)
+      h.assert_eq[String val](expected, iri.string(),
+        "URIToIRI(" + input + ")")
+    | let e: URIParseError val =>
+      h.fail("parse failed for " + input + ": " + e.string())
+    end
+
+class \nodoc\ iso _TestNormalizeIRIKnownGood is UnitTest
+  """
+  Known-good NormalizeIRI and IRIEquivalent examples.
+  """
+  fun name(): String => "uri/normalize_iri/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Mixed-case scheme + encoded ucschar normalized
+    _assert_normalize_iri(h,
+      "HTTP://Example.COM/r%C3%A9sum%C3%A9",
+      "http://example.com/r\xE9sum\xE9")
+
+    // Default port removal + ucschar decoding
+    _assert_normalize_iri(h,
+      "http://example.com:80/caf%C3%A9",
+      "http://example.com/caf\xE9")
+
+    // Dot segment removal + ucschar decoding
+    _assert_normalize_iri(h,
+      "http://example.com/a/../%C3%A9",
+      "http://example.com/\xE9")
+
+    // Encoded unreserved decoded + ucschar decoded
+    _assert_normalize_iri(h,
+      "http://example.com/%7E%C3%A9",
+      "http://example.com/~\xE9")
+
+    // IRI/URI cross-equivalence
+    _assert_iri_equivalent(h,
+      "http://example.com/r\xE9sum\xE9",
+      "http://example.com/r%C3%A9sum%C3%A9",
+      true)
+
+    // IRI with case difference
+    _assert_iri_equivalent(h,
+      "HTTP://Example.COM/caf\xE9",
+      "http://example.com/caf%c3%a9",
+      true)
+
+    // Different paths are not equivalent: è (U+00E8) vs é (U+00E9)
+    _assert_iri_equivalent(h,
+      "http://example.com/\xE9",
+      "http://example.com/\xE8",
+      false)
+
+  fun _assert_normalize_iri(
+    h: TestHelper,
+    input: String,
+    expected: String)
+  =>
+    match ParseURI(input)
+    | let u: URI val =>
+      match NormalizeIRI(u)
+      | let normalized: URI val =>
+        h.assert_eq[String val](expected, normalized.string(),
+          "NormalizeIRI(" + input + ")")
+      | let e: InvalidPercentEncoding val =>
+        h.fail("normalization failed for " + input + ": " + e.string())
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for " + input + ": " + e.string())
+    end
+
+  fun _assert_iri_equivalent(
+    h: TestHelper,
+    a_str: String,
+    b_str: String,
+    expected: Bool)
+  =>
+    match (ParseURI(a_str), ParseURI(b_str))
+    | (let a: URI val, let b: URI val) =>
+      match IRIEquivalent(a, b)
+      | let result: Bool =>
+        h.assert_eq[Bool](expected, result,
+          "IRIEquivalent(" + a_str + ", " + b_str + ")")
+      | let e: InvalidPercentEncoding val =>
+        h.fail("equivalence failed for (" + a_str + ", " + b_str
+          + "): " + e.string())
+      end
+    else
+      h.fail("parse failed for (" + a_str + ", " + b_str + ")")
+    end
+
+// ============================================================================
+// Generators
+// ============================================================================
+
+primitive _IRIStringGenerator
+  """
+  Generate URI strings with mixed ASCII and Unicode content.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.one_of[String val]([
+      // Pure ASCII
+      "http://example.com/path?q=1#frag"
+      // BMP ucschar: é (U+00E9)
+      "http://example.com/caf\xE9"
+      // Supplementary plane: U+1F600
+      "http://example.com/\U01F600"
+      // Mixed ASCII and ucschar
+      "http://example.com/r\xE9sum\xE9?q=\xE9"
+      // Non-ASCII in host: ü (U+00FC)
+      "http://b\xFCcher.example.com/"
+      // ucschar in fragment
+      "http://example.com/path#\xE9"
+      // Multiple non-ASCII chars: àèì
+      "http://example.com/\xE0/\xE8/\xEC"
+      // CJK character: 世 (U+4E16)
+      "http://example.com/\u4E16"
+    ])
+
+primitive _URIWithEncodedNonASCIIGenerator
+  """
+  Generate URI strings with percent-encoded non-ASCII bytes.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.one_of[String val]([
+      // Encoded ucschar: é = C3 A9
+      "http://example.com/r%C3%A9sum%C3%A9"
+      // Encoded supplementary: U+10000 = F0 90 80 80
+      "http://example.com/%F0%90%80%80"
+      // Encoded iprivate in query: U+E000 = EE 80 80
+      "http://example.com/?q=%EE%80%80"
+      // Mixed ucschar and ASCII encoding
+      "http://example.com/%C3%A9/%20"
+      // Non-ucschar stays encoded: U+009F = C2 9F
+      "http://example.com/%C2%9F"
+      // Bidi format char: U+200E = E2 80 8E
+      "http://example.com/%E2%80%8E"
+      // Encoded CJK: U+4E16 = E4 B8 96
+      "http://example.com/%E4%B8%96"
+      // Lowercase hex
+      "http://example.com/%c3%a9"
+    ])
+
+primitive _IRIUcscharOnlyGenerator
+  """
+  Generate IRI strings containing only ucschar non-ASCII codepoints
+  (no iprivate), suitable for roundtrip testing.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.one_of[String val]([
+      // é in path
+      "http://example.com/caf\xE9"
+      // Multiple BMP ucschar: àè
+      "http://example.com/\xE0/\xE8"
+      // CJK in path: 世界
+      "http://example.com/\u4E16\u754C"
+      // ucschar in query
+      "http://example.com/?q=\xE9"
+      // ucschar in fragment
+      "http://example.com/#\xE9"
+      // Supplementary plane: U+10000
+      "http://example.com/\U010000"
+      // Pure ASCII (trivial case)
+      "http://example.com/path"
+    ])
+
+primitive _UcscharStringGenerator
+  """
+  Generate raw strings containing ucschar codepoints.
+  """
+  fun apply(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "caf\xE9"           // é
+      "\xE0\xE8\xEC"      // àèì
+      "\u4E16\u754C"       // 世界
+      "\U010000"         // U+10000
+      "r\xE9sum\xE9"      // résumé
+      "hello"              // pure ASCII
+    ])

--- a/uri/iri_equivalent.pony
+++ b/uri/iri_equivalent.pony
@@ -1,0 +1,25 @@
+primitive IRIEquivalent
+  """
+  Test whether two IRIs (or an IRI and a URI) are equivalent under
+  RFC 3987 normalization.
+
+  Normalizes both inputs with `NormalizeIRI` and compares them
+  structurally. This detects equivalence across IRI and URI forms —
+  for example, a literal `é` and its percent-encoded form `%C3%A9`
+  are equivalent.
+
+  Returns `InvalidPercentEncoding` if either input contains a malformed
+  percent-encoded sequence.
+  """
+  fun apply(a: URI val, b: URI val)
+    : (Bool | InvalidPercentEncoding val)
+  =>
+    let norm_a = match NormalizeIRI(a)
+    | let u: URI val => u
+    | let e: InvalidPercentEncoding val => return e
+    end
+    let norm_b = match NormalizeIRI(b)
+    | let u: URI val => u
+    | let e: InvalidPercentEncoding val => return e
+    end
+    norm_a == norm_b

--- a/uri/iri_percent_encode.pony
+++ b/uri/iri_percent_encode.pony
@@ -1,0 +1,70 @@
+primitive IRIPercentEncode
+  """
+  IRI-aware percent-encoding for constructing IRIs from unencoded text.
+
+  Like `PercentEncode`, but preserves non-ASCII characters that are allowed
+  literally in IRIs per RFC 3987: `ucschar` codepoints in all components,
+  plus `iprivate` codepoints in the query component. Non-ASCII characters
+  outside these ranges are percent-encoded byte-by-byte.
+
+  ASCII encoding rules are identical to `PercentEncode` — the `URIPart`
+  parameter selects the same component-specific allowed characters.
+  """
+  fun apply(input: String val, part: URIPart): String val =>
+    let allow_iprivate = match part
+    | URIPartQuery => true
+    else false
+    end
+
+    let out = String(input.size())
+    var i: USize = 0
+    while i < input.size() do
+      try
+        let c = input(i)?
+        if c < 0x80 then
+          // ASCII: use standard URI encoding rules
+          if PercentEncode._allowed(c, part) then
+            out.push(c)
+          else
+            out.append(PercentEncode._encode_byte(c))
+          end
+          i = i + 1
+        else
+          // Non-ASCII: check if the UTF-8 sequence is an allowed IRI char
+          (let cp, let cp_len) = input.utf32(i.isize())?
+          let byte_len = cp_len.usize()
+          if _is_allowed_iri(cp, allow_iprivate) then
+            // Emit the raw UTF-8 bytes
+            var j: USize = 0
+            while j < byte_len do
+              out.push(input(i + j)?)
+              j = j + 1
+            end
+          else
+            // Percent-encode each UTF-8 byte
+            var j: USize = 0
+            while j < byte_len do
+              out.append(PercentEncode._encode_byte(input(i + j)?))
+              j = j + 1
+            end
+          end
+          i = i + byte_len
+        end
+      else
+        _Unreachable()
+      end
+    end
+    out.clone()
+
+  fun _is_allowed_iri(cp: U32, allow_iprivate: Bool): Bool =>
+    // RFC 3987 section 4.1: bidi formatting chars must stay encoded
+    if _IRIChars.is_bidi_format(cp) then
+      return false
+    end
+    if _IRIChars.is_ucschar(cp) then
+      return true
+    end
+    if allow_iprivate and _IRIChars.is_iprivate(cp) then
+      return true
+    end
+    false

--- a/uri/iri_to_uri.pony
+++ b/uri/iri_to_uri.pony
@@ -1,0 +1,75 @@
+primitive IRIToURI
+  """
+  Convert an IRI to a URI by percent-encoding all non-ASCII bytes.
+
+  Each component is processed byte-by-byte: bytes >= 0x80 become `%HH`,
+  existing `%XX` triplets pass through unchanged, and ASCII bytes pass
+  through unchanged. The scheme component is always ASCII per RFC 3986
+  and is passed through without modification.
+
+  Always succeeds — any byte sequence is valid input.
+  """
+  fun apply(iri: URI val): URI val =>
+    let uri_authority: (URIAuthority | None) = match iri.authority
+    | let a: URIAuthority =>
+      let uri_userinfo: (String | None) = match a.userinfo
+      | let u: String => _encode(u)
+      | None => None
+      end
+      URIAuthority(uri_userinfo, _encode(a.host), a.port)
+    | None => None
+    end
+
+    let uri_query: (String | None) = match iri.query
+    | let q: String => _encode(q)
+    | None => None
+    end
+
+    let uri_fragment: (String | None) = match iri.fragment
+    | let f: String => _encode(f)
+    | None => None
+    end
+
+    URI(iri.scheme, uri_authority, _encode(iri.path),
+      uri_query, uri_fragment)
+
+  fun _is_hex(c: U8): Bool =>
+    ((c >= '0') and (c <= '9'))
+      or ((c >= 'A') and (c <= 'F'))
+      or ((c >= 'a') and (c <= 'f'))
+
+  fun _encode(s: String val): String val =>
+    var has_non_ascii: Bool = false
+    for c in s.values() do
+      if c >= 0x80 then
+        has_non_ascii = true
+        break
+      end
+    end
+    if not has_non_ascii then return s end
+
+    let out = String(s.size() * 2)
+    var i: USize = 0
+    while i < s.size() do
+      try
+        let c = s(i)?
+        if (c == '%') and ((i + 2) < s.size())
+          and _is_hex(s(i + 1)?) and _is_hex(s(i + 2)?)
+        then
+          // Pass through existing percent-encoded triplets
+          out.push(c)
+          out.push(s(i + 1)?)
+          out.push(s(i + 2)?)
+          i = i + 3
+        elseif c >= 0x80 then
+          out.append(PercentEncode._encode_byte(c))
+          i = i + 1
+        else
+          out.push(c)
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+    end
+    out.clone()

--- a/uri/normalize_iri.pony
+++ b/uri/normalize_iri.pony
@@ -1,0 +1,19 @@
+primitive NormalizeIRI
+  """
+  Normalize an IRI per RFC 3987 section 5.3.
+
+  Applies `NormalizeURI` (RFC 3986 section 6 syntax-based and scheme-based
+  normalization), then converts the result to IRI form with `URIToIRI` to
+  decode `ucschar` sequences back to literal UTF-8.
+
+  NFC normalization is not applied — input is assumed to be NFC-normalized
+  already (RFC 3987 section 5.3.2.4).
+
+  Returns `InvalidPercentEncoding` if any component contains a malformed
+  percent-encoded sequence.
+  """
+  fun apply(iri: URI val): (URI val | InvalidPercentEncoding val) =>
+    match NormalizeURI(iri)
+    | let normalized: URI val => URIToIRI(normalized)
+    | let e: InvalidPercentEncoding val => e
+    end

--- a/uri/uri.pony
+++ b/uri/uri.pony
@@ -75,6 +75,27 @@ and `RemoveDotSegments` for standalone path normalization.
 
 For URI template expansion (RFC 6570), use the `uri/template` subpackage.
 
+## IRI Support (RFC 3987)
+
+`ParseURI`, `ResolveURI`, `PercentDecode`, and `PercentEncode` handle IRIs
+natively — `ParseURI` only looks for ASCII structural delimiters, so
+non-ASCII bytes pass through correctly, and `URI` stores components as
+`String` (UTF-8).
+
+The IRI-specific primitives handle conversion between IRI and URI forms:
+
+Use `IRIToURI` to convert an IRI to a URI by percent-encoding all non-ASCII
+bytes. Use `URIToIRI` for the reverse — selectively decoding percent-encoded
+UTF-8 sequences that are valid `ucschar` (or `iprivate` in query).
+
+Use `IRIPercentEncode` instead of `PercentEncode` when constructing IRIs
+from unencoded text — it preserves `ucschar` codepoints as literal UTF-8
+while applying the same ASCII encoding rules.
+
+Use `NormalizeIRI` for IRI-aware normalization (applies `NormalizeURI` then
+decodes `ucschar` sequences back to literal UTF-8). Use `IRIEquivalent`
+to test equivalence across IRI and URI forms.
+
 ## Planned Features
 
 * **URI Building** - Construct URIs from components with proper encoding

--- a/uri/uri_to_iri.pony
+++ b/uri/uri_to_iri.pony
@@ -1,0 +1,132 @@
+primitive URIToIRI
+  """
+  Convert a URI to an IRI by selectively decoding percent-encoded UTF-8
+  sequences that represent allowed IRI characters.
+
+  Percent-encoded sequences that decode to valid UTF-8 `ucschar` codepoints
+  (RFC 3987 section 2.2) are replaced with their literal UTF-8 bytes. In the
+  query component, `iprivate` codepoints are also decoded. Bidi formatting
+  characters (U+200E, U+200F, U+202A-202E) always stay percent-encoded per
+  RFC 3987 section 4.1.
+
+  Sequences that don't form valid UTF-8, or decode to codepoints outside
+  the allowed ranges, remain percent-encoded. Always succeeds.
+  """
+  fun apply(uri: URI val): URI val =>
+    let iri_authority: (URIAuthority | None) = match uri.authority
+    | let a: URIAuthority =>
+      let iri_userinfo: (String | None) = match a.userinfo
+      | let u: String => _decode_iri(u, false)
+      | None => None
+      end
+      URIAuthority(iri_userinfo, _decode_iri(a.host, false), a.port)
+    | None => None
+    end
+
+    let iri_query: (String | None) = match uri.query
+    | let q: String => _decode_iri(q, true)
+    | None => None
+    end
+
+    let iri_fragment: (String | None) = match uri.fragment
+    | let f: String => _decode_iri(f, false)
+    | None => None
+    end
+
+    URI(uri.scheme, iri_authority, _decode_iri(uri.path, false),
+      iri_query, iri_fragment)
+
+  fun _decode_iri(s: String val, allow_iprivate: Bool): String val =>
+    if not s.contains("%") then return s end
+
+    let out = String(s.size())
+    var i: USize = 0
+    while i < s.size() do
+      try
+        let c = s(i)?
+        if (c == '%') and ((i + 2) < s.size()) then
+          // Try to decode a UTF-8 sequence from percent-encoded bytes.
+          // If hex decoding fails (non-hex digits), fall through to
+          // pass the triplet through unchanged.
+          var decoded = false
+          try
+            let first_byte = _decode_hex(s, i)?
+            let seq_len = _utf8_sequence_length(first_byte)
+            if (seq_len > 1) and ((i + (seq_len * 3)) <= s.size()) then
+              let bytes = String(seq_len)
+              bytes.push(first_byte)
+              var j: USize = 1
+              var valid = true
+              while j < seq_len do
+                let byte_offset = i + (j * 3)
+                try
+                  if s(byte_offset)? != '%' then
+                    valid = false
+                    break
+                  end
+                  bytes.push(_decode_hex(s, byte_offset)?)
+                else
+                  valid = false
+                  break
+                end
+                j = j + 1
+              end
+
+              if valid and (bytes.size() == seq_len) then
+                (let cp, let cp_len) = bytes.utf32(0)?
+                if (cp_len.usize() == seq_len)
+                  and _should_decode(cp, allow_iprivate)
+                then
+                  for b in bytes.values() do
+                    out.push(b)
+                  end
+                  i = i + (seq_len * 3)
+                  decoded = true
+                end
+              end
+            end
+          end
+          if not decoded then
+            // Keep the original %XX triplet (or malformed % sequence)
+            out.push(s(i)?)
+            out.push(s(i + 1)?)
+            out.push(s(i + 2)?)
+            i = i + 3
+          end
+        else
+          out.push(c)
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+    end
+    out.clone()
+
+  fun _decode_hex(s: String val, offset: USize): U8 ? =>
+    """Decode a single %HH triplet starting at offset."""
+    let hi = PercentDecode._hex_value(s(offset + 1)?)?
+    let lo = PercentDecode._hex_value(s(offset + 2)?)?
+    (hi * 16) + lo
+
+  fun _utf8_sequence_length(first_byte: U8): USize =>
+    """Determine UTF-8 sequence length from the leading byte."""
+    if (first_byte and 0x80) == 0 then 1
+    elseif (first_byte and 0xE0) == 0xC0 then 2
+    elseif (first_byte and 0xF0) == 0xE0 then 3
+    elseif (first_byte and 0xF8) == 0xF0 then 4
+    else 1 // Invalid leading byte — treat as single byte
+    end
+
+  fun _should_decode(cp: U32, allow_iprivate: Bool): Bool =>
+    """Check if a codepoint should be decoded to literal UTF-8."""
+    if _IRIChars.is_bidi_format(cp) then
+      return false
+    end
+    if _IRIChars.is_ucschar(cp) then
+      return true
+    end
+    if allow_iprivate and _IRIChars.is_iprivate(cp) then
+      return true
+    end
+    false


### PR DESCRIPTION
Add IRI (Internationalized Resource Identifier) support for working with URIs that contain Unicode characters per RFC 3987. `ParseURI` and `ResolveURI` already handle IRIs natively since they only examine ASCII structural delimiters — the new primitives handle conversion between IRI and URI forms, IRI-aware encoding, normalization, and equivalence.

New public API:
- `IRIToURI` — convert IRI to URI by percent-encoding non-ASCII bytes
- `URIToIRI` — convert URI to IRI by decoding allowed non-ASCII sequences
- `IRIPercentEncode` — IRI-aware encoding that preserves `ucschar` codepoints
- `NormalizeIRI` — IRI-aware normalization (applies `NormalizeURI` then `URIToIRI`)
- `IRIEquivalent` — equivalence testing across IRI and URI forms

Internal `_IRIChars` provides codepoint classification for `ucschar`, `iprivate`, and bidi formatting character ranges. Bidi formatting characters (U+200E, U+200F, U+202A-202E) are always kept percent-encoded per RFC 3987 section 4.1.

14 tests (10 property-based, 4 example-based) covering boundary conditions, roundtripping, idempotence, equivalence, and encoding correctness. Example program included.