### PR TITLE
Add form-urlencoded parsing example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,10 @@ Parses a URI containing non-ASCII characters and demonstrates IRI/URI round-trip
 
 Expands URI templates (RFC 6570) by parsing a template string with `URITemplate` and binding variables with `URITemplateVariables`. Demonstrates all variable types (strings, lists, pairs), multiple operator styles (simple, reserved `+`, fragment `#`, path `/`, query `?`), the explode modifier `*`, and the prefix modifier. Also shows error handling via `URITemplateParse`.
 
+## [form-urlencoded](form-urlencoded/)
+
+Parses `application/x-www-form-urlencoded` strings into key-value pairs using `ParseFormURLEncoded` and `FormURLEncoded`. Demonstrates single-value lookup with `get()`, multi-value lookup with `get_all()` for duplicate keys, presence checking with `contains()`, iterating all pairs, plus-as-space and percent-encoding decoding, and error handling for invalid percent-encoding. Also shows the `URI.query_params()` convenience wrapper for extracting query parameters from a parsed URI.
+
 ## [template-builder](template-builder/)
 
 Performs one-shot URI template expansion using `URITemplateBuilder`'s fluent API, which combines template parsing and variable binding into a single chain. Demonstrates all three variable types (`set()`, `set_list()`, `set_pairs()`) and error handling for invalid templates.

--- a/examples/form-urlencoded/main.pony
+++ b/examples/form-urlencoded/main.pony
@@ -1,0 +1,84 @@
+// in your code this `use` statement would be:
+// use "uri"
+use "../../uri"
+
+actor Main
+  """
+  Demonstrates form-urlencoded parsing.
+  """
+  new create(env: Env) =>
+    env.out.print("Form URL-Encoded Parsing Examples")
+    env.out.print("=================================")
+    env.out.print("")
+
+    // Parse a form-urlencoded string (e.g., from an HTTP POST body)
+    env.out.print("Parsing a standalone string:")
+    match \exhaustive\ ParseFormURLEncoded("username=jane&color=blue&color=green")
+    | let params: FormURLEncoded val =>
+      // Look up a single value
+      match params.get("username")
+      | let v: String => env.out.print("  username: " + v)
+      end
+
+      // Duplicate keys — get_all() returns every value in order
+      let colors = params.get_all("color")
+      env.out.print("  colors:   " + ", ".join(colors.values()))
+
+      // Presence check
+      env.out.print("  has username? " + params.contains("username").string())
+      env.out.print("  has email?    " + params.contains("email").string())
+
+      // Iterate all pairs
+      env.out.print("  all pairs (" + params.size().string() + "):")
+      for (k, v) in params.pairs() do
+        env.out.print("    " + k + " = " + v)
+      end
+    | let e: InvalidPercentEncoding val =>
+      env.out.print("  Decode error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // Plus signs decode as spaces, percent-encoding is decoded
+    env.out.print("Decoding special characters:")
+    match \exhaustive\ ParseFormURLEncoded("greeting=hello+world&path=%2Fhome%2Fuser")
+    | let params: FormURLEncoded val =>
+      match params.get("greeting")
+      | let v: String => env.out.print("  greeting: " + v)
+      end
+      match params.get("path")
+      | let v: String => env.out.print("  path:     " + v)
+      end
+    | let e: InvalidPercentEncoding val =>
+      env.out.print("  Decode error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // Error handling — invalid percent-encoding
+    env.out.print("Error handling:")
+    match \exhaustive\ ParseFormURLEncoded("key=%ZZ")
+    | let _: FormURLEncoded val =>
+      env.out.print("  (unexpected success)")
+    | let e: InvalidPercentEncoding val =>
+      env.out.print("  Expected error: " + e.string())
+    end
+
+    env.out.print("")
+
+    // URI.query_params() — convenience wrapper for query strings
+    env.out.print("Parsing query parameters from a URI:")
+    match \exhaustive\ ParseURI("https://example.com/search?q=pony+lang&limit=10")
+    | let u: URI val =>
+      match u.query_params()
+      | let params: FormURLEncoded val =>
+        match params.get("q")
+        | let v: String => env.out.print("  q:     " + v)
+        end
+        match params.get("limit")
+        | let v: String => env.out.print("  limit: " + v)
+        end
+      end
+    | let e: URIParseError val =>
+      env.out.print("  Parse error: " + e.string())
+    end


### PR DESCRIPTION
Adds a new example demonstrating `ParseFormURLEncoded`, `FormURLEncoded`, and `URI.query_params()`. Covers standalone string parsing, single and multi-value lookup (`get`, `get_all`), presence checking (`contains`), pair iteration, plus-as-space and percent-encoding decoding, error handling for invalid percent-encoding, and the `URI.query_params()` convenience wrapper.

Closes #33